### PR TITLE
Additional Debug Info

### DIFF
--- a/station-flattening-v0/src/main/java/net/modificationstation/stationapi/mixin/flattening/MixinInGame.java
+++ b/station-flattening-v0/src/main/java/net/modificationstation/stationapi/mixin/flattening/MixinInGame.java
@@ -53,7 +53,8 @@ public abstract class MixinInGame extends DrawableHelper {
 				
 				Iterator<Property<?>> iterator = properties.iterator();
 				while (iterator.hasNext()) {
-					text = iterator.next().toString();
+					Property<?> property = iterator.next();
+					text = property.getName() + ": " + state.get(property);
 					drawTextWithShadow(var8, text, var6 - var8.getTextWidth(text) - 2, offset += 10, 14737632);
 				}
 			}

--- a/station-flattening-v0/src/main/java/net/modificationstation/stationapi/mixin/flattening/MixinInGame.java
+++ b/station-flattening-v0/src/main/java/net/modificationstation/stationapi/mixin/flattening/MixinInGame.java
@@ -1,0 +1,71 @@
+package net.modificationstation.stationapi.mixin.flattening;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.DrawableHelper;
+import net.minecraft.client.gui.InGame;
+import net.minecraft.client.render.TextRenderer;
+import net.minecraft.client.util.ScreenScaler;
+import net.minecraft.tileentity.TileEntityBase;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.hit.HitType;
+import net.modificationstation.stationapi.api.block.BlockState;
+import net.modificationstation.stationapi.api.level.BlockStateView;
+import net.modificationstation.stationapi.api.state.property.Property;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.At.Shift;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+@Mixin(InGame.class)
+public abstract class MixinInGame extends DrawableHelper {
+	@Shadow private Minecraft minecraft;
+	
+	@Unique
+	@Inject(
+		method = "renderHud(FZII)V",
+		at = @At(value = "INVOKE", target = "Ljava/lang/Runtime;maxMemory()J", shift = Shift.BEFORE),
+		locals = LocalCapture.CAPTURE_FAILSOFT
+	)
+	private void stapi_renderHud(float bl, boolean i, int j, int par4, CallbackInfo ci, ScreenScaler scaler, int var6, int var7, TextRenderer var8) {
+		HitResult hit = minecraft.hitResult;
+		int offset = 22;
+		if (hit != null && hit.type == HitType.field_789) {
+			BlockState state = ((BlockStateView) minecraft.level).getBlockState(hit.x, hit.y, hit.z);
+			
+			String text = "Block: " + state.getBlock().getTranslatedName();
+			drawTextWithShadow(var8, text, var6 - var8.getTextWidth(text) - 2, offset += 10, 16777215);
+			
+			text = "Meta: " + minecraft.level.getTileMeta(hit.x, hit.y, hit.z);
+			drawTextWithShadow(var8, text, var6 - var8.getTextWidth(text) - 2, offset += 10, 16777215);
+			
+			Collection<Property<?>> properties = state.getProperties();
+			if (properties.size() > 1) {
+				text = "Properties:";
+				drawTextWithShadow(var8, text, var6 - var8.getTextWidth(text) - 2, offset += 10, 16777215);
+				
+				Iterator<Property<?>> iterator = properties.iterator();
+				while (iterator.hasNext()) {
+					text = iterator.next().toString();
+					drawTextWithShadow(var8, text, var6 - var8.getTextWidth(text) - 2, offset += 10, 14737632);
+				}
+			}
+			
+			if (FabricLoader.getInstance().isDevelopmentEnvironment()) {
+				TileEntityBase entity = minecraft.level.getTileEntity(hit.x, hit.y, hit.z);
+				if (entity != null) {
+					String className = entity.getClass().getName();
+					text = "Tile Entity: " + className.substring(className.lastIndexOf('.') + 1);
+					drawTextWithShadow(var8, text, var6 - var8.getTextWidth(text) - 2, offset + 20, 16777215);
+				}
+			}
+		}
+	}
+}

--- a/station-flattening-v0/src/main/resources/station-flattening-v0.mixins.json
+++ b/station-flattening-v0/src/main/resources/station-flattening-v0.mixins.json
@@ -19,7 +19,8 @@
     "MixinLevelMonsterSpawner",
     "MixinLevelProperties",
     "MixinOverworldLevelSource",
-    "MixinWorldPopulationRegion"
+    "MixinWorldPopulationRegion",
+    "MixinInGame"
   ],
   "client": [
     "MixinClientLevel",


### PR DESCRIPTION
This small PR adds some more info on debug menu (F3) related to blockstates. As StAPI use new blockstates system debugging with some additional values will be much easier. Information is added to top right corner (similar to modern MC).

Example for vanilla blocks:
![2022-06-06_19 07 40](https://user-images.githubusercontent.com/17707380/172201322-b67881b7-2b81-46b9-8e81-3e725a35392c.png)

Example for modded blocks (block itself is missing localisation):
![2022-06-06_19 12 35](https://user-images.githubusercontent.com/17707380/172201435-04224fc7-2382-446f-ae7b-0587163918fc.png)

PR is ready for review
