### PR TITLE
ServerLoginSuccessEvent Mod List

### DIFF
--- a/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/api/network/ModdedPacketHandler.java
+++ b/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/api/network/ModdedPacketHandler.java
@@ -1,6 +1,10 @@
 package net.modificationstation.stationapi.api.network;
 
+import java.util.*;
+
 public interface ModdedPacketHandler {
 
     boolean isModded();
+
+    Map<String, String> getMods();
 }

--- a/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/impl/network/ModdedPacketHandlerSetter.java
+++ b/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/impl/network/ModdedPacketHandlerSetter.java
@@ -1,6 +1,8 @@
 package net.modificationstation.stationapi.impl.network;
 
+import java.util.*;
+
 public interface ModdedPacketHandlerSetter {
 
-    void setModded();
+    void setModded(Map<String, String> mods);
 }

--- a/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/impl/network/VanillaChecker.java
+++ b/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/impl/network/VanillaChecker.java
@@ -13,8 +13,7 @@ import net.modificationstation.stationapi.api.resource.language.LanguageManager;
 import net.modificationstation.stationapi.api.util.Namespace;
 import net.modificationstation.stationapi.api.util.Null;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
 import static net.modificationstation.stationapi.api.StationAPI.LOGGER;
 

--- a/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/impl/server/network/ServerVanillaChecker.java
+++ b/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/impl/server/network/ServerVanillaChecker.java
@@ -1,5 +1,6 @@
 package net.modificationstation.stationapi.impl.server.network;
 
+import net.fabricmc.loader.api.FabricLoader;
 import net.fabricmc.loader.api.ModContainer;
 import net.fabricmc.loader.api.metadata.ModMetadata;
 import net.mine_diver.unsafeevents.listener.EventListener;
@@ -28,8 +29,11 @@ public class ServerVanillaChecker {
 
     @EventListener
     private static void onPlayerLogin(PlayerAttemptLoginEvent event) {
-        if ((event.loginHelloPacket.worldSeed & MASK) == MASK)
-            ((ModdedPacketHandlerSetter) event.serverLoginNetworkHandler).setModded();
+        if ((event.loginHelloPacket.worldSeed & MASK) == MASK) {
+            Map<String, String> mods = new HashMap<>();
+            FabricLoader.getInstance().getAllMods().forEach(modContainer -> mods.put(modContainer.getMetadata().getName(), modContainer.getMetadata().getVersion().getFriendlyString()));
+            ((ModdedPacketHandlerSetter) event.serverLoginNetworkHandler).setModded(mods);
+        }
         else if (!CLIENT_REQUIRED_MODS.isEmpty()) {
             LOGGER.error("Player \"" + event.loginHelloPacket.username + "\" attempted joining the server without " + NAMESPACE.getName() + ", disconnecting.");
             event.serverLoginNetworkHandler.disconnect(I18n.getTranslation("disconnect.stationapi:missing_station"));

--- a/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/mixin/network/LoginHelloPacketMixin.java
+++ b/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/mixin/network/LoginHelloPacketMixin.java
@@ -2,12 +2,18 @@ package net.modificationstation.stationapi.mixin.network;
 
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.network.packet.login.LoginHelloPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.*;
+import java.util.stream.*;
 
 import static net.modificationstation.stationapi.api.StationAPI.NAMESPACE;
 import static net.modificationstation.stationapi.impl.network.VanillaChecker.MASK;
@@ -23,8 +29,13 @@ class LoginHelloPacketMixin {
             at = @At("RETURN")
     )
     @Environment(EnvType.SERVER)
-    private void stationapi_injectStAPIFlag(String username, int protocolVersion, long worldSeed, byte dimensionId, CallbackInfo ci) {
+    private void stationapi_injectStAPIFlagAndModList(String username, int protocolVersion, long worldSeed, byte dimensionId, CallbackInfo ci) {
         this.username += NAMESPACE + ";";
+
+        List<String> mods = FabricLoader.getInstance().getAllMods().stream().map((modContainer -> modContainer.getMetadata().getId() + "=" + modContainer.getMetadata().getVersion().getFriendlyString())).toList();
+        mods.forEach(mod -> this.username += mod + ":");
+        this.username = this.username.replaceFirst(":$", "");
+        this.username += ";";
     }
 
     @Inject(
@@ -35,4 +46,17 @@ class LoginHelloPacketMixin {
     private void stationapi_injectStAPIFlag(String username, int protocolVersion, CallbackInfo ci) {
         worldSeed |= MASK;
     }
+
+    @ModifyConstant(
+            method = "read",
+            constant = @Constant(
+                    ordinal = 0,
+                    intValue = 16
+            ),
+            remap = false
+    )
+    private int stationapi_injectHugeStringLimit(int constant) {
+        return Short.MAX_VALUE;
+    }
+
 }

--- a/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/mixin/network/NetworkHandlerMixin.java
+++ b/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/mixin/network/NetworkHandlerMixin.java
@@ -6,20 +6,26 @@ import net.modificationstation.stationapi.impl.network.ModdedPacketHandlerSetter
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
+import java.util.*;
+
 @Mixin(NetworkHandler.class)
 class NetworkHandlerMixin implements ModdedPacketHandler, ModdedPacketHandlerSetter {
-    @Unique
-    private boolean modded;
+
+    private Map<String, String> mods;
 
     @Override
     @Unique
     public boolean isModded() {
-        return modded;
+        return mods != null;
     }
 
     @Override
     @Unique
-    public void setModded() {
-        modded = true;
+    public void setModded(Map<String, String> mods) {
+        this.mods = mods;
+    }
+
+    public Map<String, String> getMods() {
+        return mods;
     }
 }

--- a/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/mixin/network/server/ServerLoginNetworkHandlerMixin.java
+++ b/station-vanilla-checker-v0/src/main/java/net/modificationstation/stationapi/mixin/network/server/ServerLoginNetworkHandlerMixin.java
@@ -27,7 +27,8 @@ class ServerLoginNetworkHandlerMixin {
             locals = LocalCapture.CAPTURE_FAILHARD
     )
     private void stationapi_checkModded(LoginHelloPacket arg, CallbackInfo ci, ServerPlayerEntity var2, class_73 var3, Vec3i var4, ServerPlayNetworkHandler var5) {
-        if (((ModdedPacketHandler) this).isModded())
-            ((ModdedPacketHandlerSetter) var5).setModded();
+        ModdedPacketHandler moddedPacketHandler = ((ModdedPacketHandler) this);
+        if (moddedPacketHandler.isModded())
+            ((ModdedPacketHandlerSetter) var5).setModded(moddedPacketHandler.getMods());
     }
 }


### PR DESCRIPTION
What does this mean? The client gets a list of mods loaded on the server.

This means mods shouldn't have to rely on receiving a custom packet from a server to know in what mode to operate in.

Also changes `ModdedPacketHandlerSetter:setModded` to take `Map<String, String>`.

![image](https://github.com/ModificationStation/StationAPI/assets/8781747/631982d0-7a33-463c-a85d-ad6f47fb659f)
