### PR TITLE
VoxelShape Box[] for Blocks

### DIFF
--- a/src/test/java/net/modificationstation/sltest/mixin/FenceBlockMixin.java
+++ b/src/test/java/net/modificationstation/sltest/mixin/FenceBlockMixin.java
@@ -1,0 +1,49 @@
+package net.modificationstation.sltest.mixin;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.FenceBlock;
+import net.minecraft.block.Material;
+import net.minecraft.util.math.Box;
+import net.minecraft.world.World;
+import net.modificationstation.stationapi.api.block.HasCollisionVoxelShape;
+import net.modificationstation.stationapi.api.block.HasVoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(FenceBlock.class)
+abstract class FenceBlockMixin extends Block implements HasVoxelShape, HasCollisionVoxelShape {
+    public FenceBlockMixin(int id, Material material) {
+        super(id, material);
+    }
+
+    @Override
+    public Box[] getVoxelShape(World world, int x, int y, int z) {
+        int fenceId = Block.FENCE.id;
+        boolean posX = world.getBlockId(x + 1, y, z) == fenceId;
+        boolean negX = world.getBlockId(x - 1, y, z) == fenceId;
+        boolean posZ = world.getBlockId(x, y, z + 1) == fenceId;
+        boolean negZ = world.getBlockId(x, y, z - 1) == fenceId;
+        int ct = 1;
+        ct += posZ ? 1 : 0;
+        ct += negZ ? 1 : 0;
+        Box[] boxes = new Box[ct];
+        boxes[0] = Box.create(x + (negX ? 0 : 0.375F), y + 0.F, z + 0.375F, x + (posX ? 1.F : 0.625F), y + 1.F, z + 0.625F);
+        if (posZ) {
+            boxes[1] = Box.createCached(x + 0.375F, y, z + 0.625F, x + 0.625F, y + 1, z + 1);
+        }
+        if (negZ) {
+            int index = 1;
+            if (posZ)
+                index = 2;
+            boxes[index] = Box.createCached(x + 0.375F, y, z, x + 0.625F, y + 1, z + 0.375F);
+        }
+        return boxes;
+    }
+
+    public Box[] getCollisionVoxelShape(World world, int x, int y, int z) {
+        Box[] boxes = getVoxelShape(world, x, y, z);
+        for (Box box : boxes) {
+            box.maxY += .5;
+        }
+        return boxes;
+    }
+}

--- a/src/test/java/net/modificationstation/sltest/mixin/StairMixin.java
+++ b/src/test/java/net/modificationstation/sltest/mixin/StairMixin.java
@@ -1,0 +1,26 @@
+package net.modificationstation.sltest.mixin;
+
+import net.minecraft.block.StairsBlock;
+import net.minecraft.util.math.Box;
+import net.minecraft.world.World;
+import net.modificationstation.stationapi.api.block.HasVoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+
+@Mixin(StairsBlock.class)
+public class StairMixin implements HasVoxelShape {
+    @Override
+    public Box[] getVoxelShape(World world, int x, int y, int z) {
+        int meta = world.getBlockMeta(x, y, z);
+        if (meta < 0 || meta > 3) return new Box[0];
+        return new Box[]{
+                Box.createCached(x, y, z, x + 1, y + 0.5, z + 1),
+                switch (meta) {
+                    case 0 -> Box.createCached(x + .5, y + .5, z, x + 1, y + 1, z + 1);
+                    case 1 -> Box.createCached(x, y + .5, z, x + .5, y + 1, z + 1);
+                    case 2 -> Box.createCached(x, y + .5, z + .5, x + 1, y + 1, z + 1);
+                    case 3 -> Box.createCached(x, y + .5, z, x + 1, y + 1, z + .5);
+                    default -> throw new IllegalStateException("Unexpected stair meta: " + meta);
+                }
+        };
+    }
+}

--- a/src/test/resources/sltest.mixins.json
+++ b/src/test/resources/sltest.mixins.json
@@ -5,10 +5,12 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "BlockBaseAccessor",
+    "FenceBlockMixin",
     "MixinLevel",
     "MixinNetherLevelSource",
     "MixinObsidian",
-    "OverworldTestMixin"
+    "OverworldTestMixin",
+    "StairMixin"
   ],
   "server": [
   ],

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/api/block/HasCollisionVoxelShape.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/api/block/HasCollisionVoxelShape.java
@@ -1,0 +1,8 @@
+package net.modificationstation.stationapi.api.block;
+
+import net.minecraft.util.math.Box;
+import net.minecraft.world.World;
+
+public interface HasCollisionVoxelShape {
+    Box[] getCollisionVoxelShape(World world, int x, int y, int z);
+}

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/api/block/HasVoxelShape.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/api/block/HasVoxelShape.java
@@ -1,0 +1,8 @@
+package net.modificationstation.stationapi.api.block;
+
+import net.minecraft.util.math.Box;
+import net.minecraft.world.World;
+
+public interface HasVoxelShape {
+    Box[] getVoxelShape(World world, int x, int y, int z);
+}

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/impl/block/BoxToLinesConverter.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/impl/block/BoxToLinesConverter.java
@@ -1,0 +1,70 @@
+package net.modificationstation.stationapi.impl.block;
+
+import net.minecraft.util.math.Box;
+import net.modificationstation.stationapi.api.util.math.Vec3d;
+
+import java.util.*;
+
+public class BoxToLinesConverter {
+    public static List<Line> convertBoxesToLines(Box[] boxes, Vec3d center) {
+        List<Line> lines = new ArrayList<>();
+
+        for (Box box : boxes) {
+            Vec3d corner1 = new Vec3d(box.minX, box.minY, box.minZ);
+            Vec3d corner2 = new Vec3d(box.minX, box.minY, box.maxZ);
+            Vec3d corner3 = new Vec3d(box.minX, box.maxY, box.minZ);
+            Vec3d corner4 = new Vec3d(box.minX, box.maxY, box.maxZ);
+            Vec3d corner5 = new Vec3d(box.maxX, box.minY, box.minZ);
+            Vec3d corner6 = new Vec3d(box.maxX, box.minY, box.maxZ);
+            Vec3d corner7 = new Vec3d(box.maxX, box.maxY, box.minZ);
+            Vec3d corner8 = new Vec3d(box.maxX, box.maxY, box.maxZ);
+
+            lines.add(new Line(corner1, corner2));
+            lines.add(new Line(corner1, corner3));
+            lines.add(new Line(corner1, corner5));
+            lines.add(new Line(corner2, corner4));
+            lines.add(new Line(corner2, corner6));
+            lines.add(new Line(corner3, corner4));
+            lines.add(new Line(corner3, corner7));
+            lines.add(new Line(corner4, corner8));
+            lines.add(new Line(corner5, corner6));
+            lines.add(new Line(corner5, corner7));
+            lines.add(new Line(corner6, corner8));
+            lines.add(new Line(corner7, corner8));
+        }
+
+        // Remove coinciding edges from lines
+        removeCoincidingEdges(lines);
+
+        // Expand lines
+        for (Line line : lines) {
+            line.expand(0.002, center);
+        }
+
+        return lines;
+    }
+
+    private static void removeCoincidingEdges(List<Line> lines) {
+        Set<Line> toRemove = new HashSet<>();
+        Set<Line> toAdd = new HashSet<>();
+
+        for (int i = 0; i < lines.size(); i++) {
+            Line line1 = lines.get(i);
+            for (int j = i + 1; j < lines.size(); j++) {
+                Line line2 = lines.get(j);
+                if (line1.coincidesWith(line2)) {
+                    toRemove.add(line1);
+                    toRemove.add(line2);
+                } else if (line1.partiallyCoincidesWith(line2)) {
+                    Line[] nonOverlappingParts = line1.getNonOverlappingParts(line2);
+                    toRemove.add(line1);
+                    toRemove.add(line2);
+                    Collections.addAll(toAdd, nonOverlappingParts);
+                }
+            }
+        }
+
+        lines.removeAll(toRemove);
+        lines.addAll(toAdd);
+    }
+}

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/impl/block/Line.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/impl/block/Line.java
@@ -1,0 +1,83 @@
+package net.modificationstation.stationapi.impl.block;
+
+import net.modificationstation.stationapi.api.util.math.Vec3d;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Line {
+    public Vec3d[] points;
+
+    Line(Vec3d a, Vec3d b) {
+        points = new Vec3d[]{a, b};
+    }
+
+    public void expand(double d, Vec3d center) {
+        points[0] = movePointAwayFromCenter(points[0], center, d);
+        points[1] = movePointAwayFromCenter(points[1], center, d);
+    }
+
+    private static Vec3d movePointAwayFromCenter(Vec3d point, Vec3d center, double distance) {
+        Vec3d direction = point.subtract(center).normalize();
+        Vec3d displacement = direction.multiply(distance);
+        return point.add(displacement);
+    }
+
+    public boolean coincidesWith(Line other) {
+        return (this.points[0].equals(other.points[0]) && this.points[1].equals(other.points[1])) ||
+                (this.points[0].equals(other.points[1]) && this.points[1].equals(other.points[0]));
+    }
+
+    public boolean partiallyCoincidesWith(Line other) {
+        return this.containsPoint(other.points[0]) && this.containsPoint(other.points[1]) ||
+                other.containsPoint(this.points[0]) && other.containsPoint(this.points[1]);
+    }
+
+    private boolean containsPoint(Vec3d point) {
+        double minX = Math.min(this.points[0].x, this.points[1].x);
+        double maxX = Math.max(this.points[0].x, this.points[1].x);
+        double minY = Math.min(this.points[0].y, this.points[1].y);
+        double maxY = Math.max(this.points[0].y, this.points[1].y);
+        double minZ = Math.min(this.points[0].z, this.points[1].z);
+        double maxZ = Math.max(this.points[0].z, this.points[1].z);
+
+        return (point.x >= minX && point.x <= maxX) &&
+                (point.y >= minY && point.y <= maxY) &&
+                (point.z >= minZ && point.z <= maxZ);
+    }
+
+    public Line[] getNonOverlappingParts(Line other) {
+        List<Line> nonOverlappingParts = new ArrayList<>();
+
+        Vec3d start = this.points[0];
+        Vec3d end = this.points[1];
+
+        if (this.containsPoint(other.points[0]) && this.containsPoint(other.points[1])) {
+            // Other line is completely inside this line, split this line into two parts
+            if (!start.equals(other.points[0])) {
+                nonOverlappingParts.add(new Line(start, other.points[0]));
+            }
+            if (!end.equals(other.points[1])) {
+                nonOverlappingParts.add(new Line(other.points[1], end));
+            }
+        } else if (this.containsPoint(other.points[0])) {
+            // Other line overlaps at the start of this line
+            nonOverlappingParts.add(new Line(start, other.points[0]));
+            nonOverlappingParts.add(new Line(other.points[0], end));
+        } else if (this.containsPoint(other.points[1])) {
+            // Other line overlaps at the end of this line
+            nonOverlappingParts.add(new Line(start, other.points[1]));
+            nonOverlappingParts.add(new Line(other.points[1], end));
+        } else {
+            // This line is completely inside other line
+            if (!other.points[0].equals(start)) {
+                nonOverlappingParts.add(new Line(other.points[0], start));
+            }
+            if (!other.points[1].equals(end)) {
+                nonOverlappingParts.add(new Line(end, other.points[1]));
+            }
+        }
+
+        return nonOverlappingParts.toArray(new Line[0]);
+    }
+}

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/BlockMixinCorrectDrop.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/BlockMixinCorrectDrop.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
 @Mixin(Block.class)
-abstract class BlockMixin implements StationBlock {
+abstract class BlockMixinCorrectDrop implements StationBlock {
     @Shadow public abstract Block setTranslationKey(String string);
 
     @Override

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/BlockMixinVoxelShapes.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/BlockMixinVoxelShapes.java
@@ -1,0 +1,123 @@
+package net.modificationstation.stationapi.mixin.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.math.Box;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.World;
+import net.modificationstation.stationapi.api.block.HasCollisionVoxelShape;
+import net.modificationstation.stationapi.api.block.HasVoxelShape;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@Mixin(Block.class)
+public class BlockMixinVoxelShapes {
+    @Inject(method = "addIntersectingBoundingBox(Lnet/minecraft/world/World;IIILnet/minecraft/util/math/Box;Ljava/util/ArrayList;)V", at = @At("HEAD"), cancellable = true)
+    private void  stationapi_addBlockVoxelShapesToCollision(World world, int x, int y, int z, Box box, ArrayList<Box> boxes, CallbackInfo ci) {
+        if (this instanceof HasCollisionVoxelShape hasCollisionVoxelShape) {
+            boxes.addAll(Arrays.asList(hasCollisionVoxelShape.getCollisionVoxelShape(world, x, y, z)));
+            ci.cancel();
+        } else if (this instanceof HasVoxelShape hasVoxelShape) {
+            boxes.addAll(Arrays.asList(hasVoxelShape.getVoxelShape(world, x, y, z)));
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "raycast(Lnet/minecraft/world/World;IIILnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Vec3d;)Lnet/minecraft/util/hit/HitResult;", at = @At("HEAD"), cancellable = true)
+    private void stationapi_allowMineThroughBlockWithVoxelShapes(World world, int x, int y, int z, Vec3d startPos, Vec3d endPos, CallbackInfoReturnable<HitResult> cir) {
+        if (this instanceof HasVoxelShape hasVoxelShape) {
+            startPos = startPos.add(-x, -y, -z);
+            endPos = endPos.add(-x, -y, -z);
+            for (Box translatedBox : hasVoxelShape.getVoxelShape(world, x, y, z)) {
+                Box box = translatedBox.translate(-x, -y, -z);
+                Vec3d northVec = startPos.interpolateByX(endPos, box.minX);
+                Vec3d southVec = startPos.interpolateByX(endPos, box.maxX);
+                Vec3d downVec = startPos.interpolateByY(endPos, box.minY);
+                Vec3d upVec = startPos.interpolateByY(endPos, box.maxY);
+                Vec3d eastVec = startPos.interpolateByZ(endPos, box.minZ);
+                Vec3d westVec = startPos.interpolateByZ(endPos, box.maxZ);
+
+                if (!containsInYZPlane(box, northVec)) northVec = null;
+                if (!containsInYZPlane(box, southVec)) southVec = null;
+                if (!containsInXZPlane(box, downVec)) downVec = null;
+                if (!containsInXZPlane(box, upVec)) upVec = null;
+                if (!containsInXYPlane(box, eastVec)) eastVec = null;
+                if (!containsInXYPlane(box, westVec)) westVec = null;
+
+
+                Vec3d hitPos = null;
+                if (northVec != null && (hitPos == null || startPos.distanceTo(northVec) < startPos.distanceTo(hitPos))) {
+                    hitPos = northVec;
+                }
+
+                if (southVec != null && (hitPos == null || startPos.distanceTo(southVec) < startPos.distanceTo(hitPos))) {
+                    hitPos = southVec;
+                }
+
+                if (downVec != null && (hitPos == null || startPos.distanceTo(downVec) < startPos.distanceTo(hitPos))) {
+                    hitPos = downVec;
+                }
+
+                if (upVec != null && (hitPos == null || startPos.distanceTo(upVec) < startPos.distanceTo(hitPos))) {
+                    hitPos = upVec;
+                }
+
+                if (eastVec != null && (hitPos == null || startPos.distanceTo(eastVec) < startPos.distanceTo(hitPos))) {
+                    hitPos = eastVec;
+                }
+
+                if (westVec != null && (hitPos == null || startPos.distanceTo(westVec) < startPos.distanceTo(hitPos))) {
+                    hitPos = westVec;
+                }
+
+                if (hitPos != null) {
+                    byte side = -1;
+                    if (hitPos == northVec) side = 4;
+                    if (hitPos == southVec) side = 5;
+                    if (hitPos == downVec) side = 0;
+                    if (hitPos == upVec) side = 1;
+                    if (hitPos == eastVec) side = 2;
+                    if (hitPos == westVec) side = 3;
+
+                    cir.setReturnValue(new HitResult(x, y, z, side, hitPos.add(x, y, z)));
+                    return;
+                }
+            }
+            cir.setReturnValue(null);
+        }
+    }
+
+    @Unique
+    private boolean containsInYZPlane(Box box, Vec3d vec3d) {
+        if (vec3d == null) {
+            return false;
+        } else {
+            return vec3d.y >= box.minY && vec3d.y <= box.maxY && vec3d.z >= box.minZ && vec3d.z <= box.maxZ;
+        }
+    }
+
+    @Unique
+    private boolean containsInXZPlane(Box box, Vec3d vec3d) {
+        if (vec3d == null) {
+            return false;
+        } else {
+            return vec3d.x >= box.minX && vec3d.x <= box.maxX && vec3d.z >= box.minZ && vec3d.z <= box.maxZ;
+        }
+    }
+
+    @Unique
+    private boolean containsInXYPlane(Box box, Vec3d vec3d) {
+        if (vec3d == null) {
+            return false;
+        } else {
+            return vec3d.x >= box.minX && vec3d.x <= box.maxX && vec3d.y >= box.minY && vec3d.y <= box.maxY;
+        }
+    }
+}

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/client/WorldRendererMixin.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/client/WorldRendererMixin.java
@@ -1,0 +1,65 @@
+package net.modificationstation.stationapi.mixin.block.client;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.render.Tessellator;
+import net.minecraft.client.render.WorldRenderer;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.hit.HitResult;
+import net.minecraft.util.hit.HitResultType;
+import net.minecraft.world.World;
+import net.modificationstation.stationapi.api.block.HasVoxelShape;
+import net.modificationstation.stationapi.api.util.math.Vec3d;
+import net.modificationstation.stationapi.impl.block.Line;
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.List;
+
+import static net.modificationstation.stationapi.impl.block.BoxToLinesConverter.convertBoxesToLines;
+
+@Mixin(WorldRenderer.class)
+public abstract class WorldRendererMixin {
+    @Shadow private World world;
+
+    @Inject(method = "method_1554(Lnet/minecraft/entity/player/PlayerEntity;Lnet/minecraft/util/hit/HitResult;ILnet/minecraft/item/ItemStack;F)V", at = @At("HEAD"), cancellable = true)
+    private void stationapi_drawBlockVoxelShapesOutline(PlayerEntity playerEntity, HitResult hitResult, int i, ItemStack itemStack, float f, CallbackInfo ci) {
+        if (i == 0 && hitResult.type == HitResultType.BLOCK && world.getBlockState(hitResult.blockX, hitResult.blockY, hitResult.blockZ).getBlock() instanceof HasVoxelShape block) {
+            GL11.glEnable(3042);
+            GL11.glBlendFunc(770, 771);
+            GL11.glColor4f(0.0F, 0.0F, 0.0F, 0.4F);
+            GL11.glLineWidth(2.0F);
+            GL11.glDisable(3553);
+            GL11.glDepthMask(false);
+            int var7 = world.getBlockId(hitResult.blockX, hitResult.blockY, hitResult.blockZ);
+            if (var7 > 0) {
+                Block.BLOCKS[var7].updateBoundingBox(this.world, hitResult.blockX, hitResult.blockY, hitResult.blockZ);
+                // field_1637, field_1638, field_1639 is lastTickX, lastTickY, lastTickZ respectively
+                double var8 = playerEntity.field_1637 + (playerEntity.x - playerEntity.field_1637) * (double)f;
+                double var10 = playerEntity.field_1638 + (playerEntity.y - playerEntity.field_1638) * (double)f;
+                double var12 = playerEntity.field_1639 + (playerEntity.z - playerEntity.field_1639) * (double)f;
+
+                Vec3d center = new Vec3d(hitResult.blockX + 0.5, hitResult.blockY + 0.5, hitResult.blockZ + 0.5);
+                List<Line> linePoints = convertBoxesToLines(block.getVoxelShape(world, hitResult.blockX, hitResult.blockY, hitResult.blockZ), center);
+
+                Tessellator tessellator = Tessellator.INSTANCE;
+                tessellator.start(1);
+                for (Line linePoint : linePoints) {
+                    tessellator.vertex(-var8 + linePoint.points[0].x, -var10 + linePoint.points[0].y, -var12 + linePoint.points[0].z);
+                    tessellator.vertex(-var8 + linePoint.points[1].x, -var10 + linePoint.points[1].y, -var12 + linePoint.points[1].z);
+                }
+                tessellator.draw();
+            }
+
+            GL11.glDepthMask(true);
+            GL11.glEnable(3553);
+            GL11.glDisable(3042);
+
+            ci.cancel();
+        }
+    }
+}

--- a/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/server/ServerPlayNetworkHandlerMixin.java
+++ b/station-blocks-v0/src/main/java/net/modificationstation/stationapi/mixin/block/server/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,63 @@
+package net.modificationstation.stationapi.mixin.block.server;
+
+import net.minecraft.block.Block;
+import net.minecraft.class_73;
+import net.minecraft.entity.player.ServerPlayerEntity;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.util.math.Box;
+import net.modificationstation.stationapi.api.block.HasCollisionVoxelShape;
+import net.modificationstation.stationapi.api.block.HasVoxelShape;
+import net.modificationstation.stationapi.api.util.math.Vec3i;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public abstract class ServerPlayNetworkHandlerMixin {
+
+    @Shadow private ServerPlayerEntity field_920;
+    @Shadow private MinecraftServer field_919;
+
+    @Redirect(method = "onPlayerMove", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;method_832(DDDFF)V", ordinal = 0))
+    private void stationapi_verifyBlockIntersectionForBlockVoxelShapes(ServerPlayNetworkHandler instance, double e, double f, double g, float h, float v) {
+        class_73 world = this.field_919.method_2157(this.field_920.dimensionId);
+        Box originalPlayerBox = field_920.boundingBox;
+        Box playerBox = Box.createCached(originalPlayerBox.minX, originalPlayerBox.minY, originalPlayerBox.minZ,
+                originalPlayerBox.maxX, originalPlayerBox.maxY, originalPlayerBox.maxZ);
+
+        Vec3i min = new Vec3i(Math.floor(playerBox.minX), Math.floor(playerBox.minY), Math.floor(playerBox.minZ));
+        Vec3i max = new Vec3i(Math.ceil(playerBox.maxX), Math.ceil(playerBox.maxY), Math.ceil(playerBox.maxZ));
+
+        boolean collisionVerified = false;
+
+        for (int x = min.getX(); x <= max.getX(); x++) {
+            for (int y = min.getY(); y <= max.getY(); y++) {
+                for (int z = min.getZ(); z <= max.getZ(); z++) {
+                    Block block = world.getBlockState(x, y, z).getBlock();
+                    Box[] boxes;
+
+                    if (block instanceof HasVoxelShape hasVoxelShape) {
+                        boxes = hasVoxelShape.getVoxelShape(world, x, y, z);
+                    } else if (block instanceof HasCollisionVoxelShape hasCollisionVoxelShape) {
+                        boxes = hasCollisionVoxelShape.getCollisionVoxelShape(world, x, y, z);
+                    } else {
+                        boxes = new Box[]{block.getCollisionShape(world, x, y, z)};
+                    }
+
+                    for (Box blockBoxPart : boxes) {
+                        if (blockBoxPart == null) continue;
+                        if (playerBox.intersects(blockBoxPart)) {
+                            collisionVerified = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        if (collisionVerified) {
+            instance.method_832(e, f, g, h, v);
+        }
+    }
+}

--- a/station-blocks-v0/src/main/resources/station-blocks-v0.mixins.json
+++ b/station-blocks-v0/src/main/resources/station-blocks-v0.mixins.json
@@ -5,12 +5,19 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BlockItemMixin",
-    "BlockMixin",
+    "BlockMixinCorrectDrop",
+    "BlockMixinVoxelShapes",
     "FireBlockMixin",
     "SecondaryBlockItemMixin",
     "StatsMixin"
   ],
   "injectors": {
     "defaultRequire": 1
-  }
+  },
+  "server": [
+    "server.ServerPlayNetworkHandlerMixin"
+  ],
+  "client": [
+    "client.WorldRendererMixin"
+  ]
 }


### PR DESCRIPTION
Implements two interface to allow you to provide multiple "Box" / "VoxelShape", but specifically an array like Box[]. Confusing naming scheme because in modern VoxelShape is the modern equivalent as a container for Boxes.

- Handles multiple box collision
- Handles mining hit result
- Handles multiplayer collision check
- Handles rendering outline correctly (same outline style as modern)

Demo Images:
![image](https://github.com/ModificationStation/StationAPI/assets/18296791/0ddf7964-c841-4fc5-986a-729f8cff1c31)
![2024-07-08_06 00 24](https://github.com/ModificationStation/StationAPI/assets/18296791/7a1a606c-2e2a-444c-ade2-2f20568efadc)
Note: Fences and Stairs are only changed via mixin in example mod, and are intended to be put into AnnoyanceFix.

This should be ready for a review immediately and pulled whenever, open to all feedback.