### PR TITLE
Implement onBonemealUse on Vanilla Crops

### DIFF
--- a/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/CropBlockMixin.java
+++ b/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/CropBlockMixin.java
@@ -1,0 +1,20 @@
+package net.modificationstation.stationapi.mixin.item;
+
+import net.minecraft.block.CropBlock;
+import net.minecraft.world.World;
+import net.modificationstation.stationapi.api.block.BlockState;
+import net.modificationstation.stationapi.api.block.StationBlock;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(CropBlock.class)
+public abstract class CropBlockMixin implements StationBlock {
+
+    @Shadow public abstract void method_996(World world, int i, int j, int k);
+
+    @Override
+    public boolean onBonemealUse(World world, int x, int y, int z, BlockState state) {
+        method_996(world, x, y, z); // Full grows crop.
+        return true;
+    }
+}

--- a/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/SaplingBlockMixin.java
+++ b/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/SaplingBlockMixin.java
@@ -1,21 +1,26 @@
 package net.modificationstation.stationapi.mixin.item;
 
-import net.minecraft.block.CropBlock;
+import net.minecraft.block.SaplingBlock;
 import net.minecraft.world.World;
 import net.modificationstation.stationapi.api.block.BlockState;
 import net.modificationstation.stationapi.api.block.StationBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
-@Mixin(CropBlock.class)
-public abstract class CropBlockMixin implements StationBlock {
+import java.util.Random;
 
-    @Shadow public abstract void method_996(World world, int i, int j, int k);
+@Mixin(SaplingBlock.class)
+public abstract class SaplingBlockMixin implements StationBlock {
+    @Unique
+    private static final Random RANDOM = new Random();
+
+    @Shadow public abstract void method_533(World world, int x, int y, int z, Random random);
 
     @Override
     public boolean onBonemealUse(World world, int x, int y, int z, BlockState state) {
         if (!world.isRemote) {
-            method_996(world, x, y, z); // Full grows crop.
+            method_533(world, x, y, z, RANDOM);
         }
         return true;
     }

--- a/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/SaplingBlockMixin.java
+++ b/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/SaplingBlockMixin.java
@@ -6,21 +6,17 @@ import net.modificationstation.stationapi.api.block.BlockState;
 import net.modificationstation.stationapi.api.block.StationBlock;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 
 import java.util.Random;
 
 @Mixin(SaplingBlock.class)
 public abstract class SaplingBlockMixin implements StationBlock {
-    @Unique
-    private static final Random RANDOM = new Random();
-
     @Shadow public abstract void method_533(World world, int x, int y, int z, Random random);
 
     @Override
     public boolean onBonemealUse(World world, int x, int y, int z, BlockState state) {
         if (!world.isRemote) {
-            method_533(world, x, y, z, RANDOM);
+            method_533(world, x, y, z, world.field_214);
         }
         return true;
     }

--- a/station-items-v0/src/main/resources/station-items-v0.mixins.json
+++ b/station-items-v0/src/main/resources/station-items-v0.mixins.json
@@ -5,6 +5,7 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "BlockMixin",
+    "CropBlockMixin",
     "DyeItemMixin",
     "EntityAccessor",
     "EntityMixin",

--- a/station-items-v0/src/main/resources/station-items-v0.mixins.json
+++ b/station-items-v0/src/main/resources/station-items-v0.mixins.json
@@ -14,6 +14,7 @@
     "ItemStackMixin",
     "PlayerEntityMixin",
     "PlayerInventoryMixin",
+    "SaplingBlockMixin",
     "ScreenHandlerMixin",
     "StatsMixin",
     "dispenser.block.DispenserBlockMixin",


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/311a5089-743e-4768-83ae-3b92727cc2d9)

I think this fully satisfies #161. Neither bonemeal or the plant checks if it's fully grown, so it always returns true.

Closes #161