### PR TITLE
Fix Nether Having Skylight

### DIFF
--- a/station-flattening-v0/src/main/java/net/modificationstation/stationapi/impl/world/chunk/FlattenedChunk.java
+++ b/station-flattening-v0/src/main/java/net/modificationstation/stationapi/impl/world/chunk/FlattenedChunk.java
@@ -11,6 +11,7 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.LightType;
 import net.minecraft.world.World;
 import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.dimension.Dimension;
 import net.modificationstation.stationapi.api.StationAPI;
 import net.modificationstation.stationapi.api.block.BlockState;
 import net.modificationstation.stationapi.api.block.States;
@@ -144,7 +145,7 @@ public class FlattenedChunk extends Chunk {
     @Override
     public int getLight(int x, int y, int z, int light) {
         ChunkSection section = getSection(y);
-        int lightLevel = section == null ? 15 : section.getLight(LightType.SKY, x, y & 15, z);
+        int lightLevel = section == null ? (world.dimension.field_2177 /* hasCeiling */ ? 0 : 15) : section.getLight(LightType.SKY, x, y & 15, z);
         if (lightLevel > 0) {
             field_953 = true;
         }


### PR DESCRIPTION
Tin. Non-gameplay effecting for the most part, but this is pretty important for custom dims without natural light or a physical roof.

This implements the fix linked in #176, though mine may have a much more "correct" fix in mind.

I've not had time to test this PR yet, just about to become busy as of typing.

Fixes #176 