### PR TITLE
Fix MacOS (Again)

### DIFF
--- a/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/api/client/resource/ReloadScreenManager.java
+++ b/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/api/client/resource/ReloadScreenManager.java
@@ -151,7 +151,7 @@ public class ReloadScreenManager {
         glAlphaFunc(GL_GREATER, 0.1f);
         try {
             drawable.releaseContext();
-            drawable.destroy();
+//            drawable.destroy();
         } catch (LWJGLException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Latest macos doesn't like us destroying stapi's resource reload screen drawable for some reason.

PR is mostly here for looking into later on.