### PR TITLE
fix: bonemeal api in multiplayer

### DIFF
--- a/station-items-v0/src/main/java/net/modificationstation/stationapi/api/bonemeal/BonemealAPI.java
+++ b/station-items-v0/src/main/java/net/modificationstation/stationapi/api/bonemeal/BonemealAPI.java
@@ -79,7 +79,9 @@ public class BonemealAPI {
             BlockState worldState = world.getBlockState(x, y, z);
             if (!worldState.isAir()) return false;
             if (state.getBlock().canPlaceAt(world, x, y, z)) {
-                world.setBlockState(x, y, z, state);
+                if (!world.isRemote) {
+                    world.setBlockState(x, y, z, state);
+                }
                 return true;
             }
             return false;
@@ -94,8 +96,10 @@ public class BonemealAPI {
             BlockState worldState = world.getBlockState(x, y, z);
             if (!worldState.isAir()) return false;
             if (STATE.getBlock().canPlaceAt(world, x, y, z)) {
-                world.setBlockState(x, y, z, STATE);
-                world.setBlockMeta(x, y, z, 1);
+                if (!world.isRemote) {
+                    world.setBlockState(x, y, z, STATE);
+                    world.setBlockMeta(x, y, z, 1);
+                }
                 return true;
             }
             return false;

--- a/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/DyeItemMixin.java
+++ b/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/DyeItemMixin.java
@@ -27,13 +27,13 @@ class DyeItemMixin {
         if (state.getBlock().onBonemealUse(world, x, y, z, state)) {
             world.setBlocksDirty(x, y, z, x, y, z);
             info.setReturnValue(true);
-            item.count--;
+            if (!world.isRemote) item.count--;
             return;
         }
         if (BonemealAPI.generate(world, x, y, z, state, side)) {
             world.setBlocksDirty(x - 8, y - 8, z - 8, x + 8, y + 8, z + 8);
             info.setReturnValue(true);
-            item.count--;
+            if (!world.isRemote) item.count--;
         }
     }
 }


### PR DESCRIPTION
This PR addresses a bug in the Bonemeal API where the reimplementation of the vanilla behaviour (use on grass, etc.) leads to client/server desyncs in multiplayer. Specifically, the new code in the Bonemeal API currently doesn't implement the same `world.isRemote` checks that DyeItem.java originally does. In multiplayer, this means that a player with Station API installed will see different plants grown than on the server, and in the case of grass, they may even see dead bushes (due to a block meta desync). This issue happens regardless of whether Station API is installed on the server.

For the implementation, I chose to delegate the responsibility of checking world.isRemote to the implementors of the `generate` function, leaving modders the flexibility to fine-tune which behaviour is ran on the client, and protect the return values so that the item animations are preserved properly. As such, I only wrapped the world-modifying calls in the replacement implementations for the vanilla generators, as well as the item stack consumption. This does mean that this PR won't fix the desync for mods using the Bonemeal API; those mods will need to make similar patches themselves.

I've tested that this works correctly in singleplayer and multiplayer.