### PR TITLE
fix: make station-flattening-v0/StatMixin compile

### DIFF
--- a/station-flattening-v0/src/main/java/net/modificationstation/stationapi/mixin/flattening/StatMixin.java
+++ b/station-flattening-v0/src/main/java/net/modificationstation/stationapi/mixin/flattening/StatMixin.java
@@ -13,7 +13,7 @@ class StatMixin implements StationFlatteningStat {
     @Mutable
     @Shadow @Final public int id;
     @Unique
-    private RegistryEntry.Reference<Stat> stationapi_registryEntry;
+    private RegistryEntry.Reference.IntrusiveReserved<Stat> stationapi_registryEntry;
 
     @ModifyVariable(
             method = "<init>(ILjava/lang/String;Lnet/minecraft/stat/StatFormatter;)V",


### PR DESCRIPTION
Fixes the build issue with StatMixin in the flattening API due to the incorrect type of `stationapi_registryEntry`, using BlockMixin as a reference:

https://github.com/ModificationStation/StationAPI/blob/f6a075d80f3c2d9113bba838ed82fb9aaa1ed0de/station-flattening-v0/src/main/java/net/modificationstation/stationapi/mixin/flattening/BlockMixin.java#L85