### PR TITLE
fix: memory leak during registry growth

### DIFF
--- a/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/registry/SimpleRegistry.java
+++ b/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/registry/SimpleRegistry.java
@@ -194,8 +194,23 @@ public class SimpleRegistry<T> implements MutableRegistry<T>, RemappableRegistry
         this.keyToEntry.put(registryKey, reference);
         this.idToEntry.put(registryKey.getValue(), reference);
         this.valueToEntry.put(value, reference);
-        this.rawIdToEntry.size(Math.max(this.rawIdToEntry.size(), rawId + 1));
-        this.rawIdToEntry.set(rawId, reference);
+
+        int size = rawIdToEntry.size();
+        if (rawId == size) {
+            // If we're appending a new element, use add() to allow ReferenceArrayList to efficiently grow the capacity
+            // by at least 50% if necessary, and avoid memory leaks by resizing on each insertion.
+            rawIdToEntry.add(reference);
+        } else if (rawId > size) {
+            // Grow the array to the required size first by adding nulls. Calls grow() internally, growing it by at
+            // least 50%. More efficient than addElements, which takes an array and only uses size(), potentially
+            // incurring unnecessary additional array copies internally.
+            rawIdToEntry.addAll(Collections.nCopies(rawId - size, null));
+            rawIdToEntry.add(reference); // This may also call grow() internally, but ideally shouldn't.
+        } else {
+            // Otherwise, just use set() to change the existing value in the registry directly.
+            rawIdToEntry.set(rawId, reference);
+        }
+
         this.entryToRawId.put(value, rawId);
         if (this.nextId <= rawId) this.nextId = rawId + 1;
 
@@ -615,8 +630,22 @@ public class SimpleRegistry<T> implements MutableRegistry<T>, RemappableRegistry
             }
 
             // Add the new object, increment nextId to match.
-            rawIdToEntry.size(Math.max(this.rawIdToEntry.size(), id + 1));
-            rawIdToEntry.set(id, object);
+            int size = rawIdToEntry.size();
+            if (id == size) {
+                // If we're appending a new element, use add() to allow ReferenceArrayList to efficiently grow the
+                // capacity by at least 50% if necessary, and avoid memory leaks by resizing on each insertion.
+                rawIdToEntry.add(object);
+            } else if (id > size) {
+                // Grow the array to the required size first by adding nulls. Calls grow() internally, growing it by at
+                // least 50%. More efficient than addElements, which takes an array and only uses size(), potentially
+                // incurring unnecessary additional array copies internally.
+                rawIdToEntry.addAll(Collections.nCopies(id - size, null));
+                rawIdToEntry.add(object); // This may also call grow() internally, but ideally shouldn't.
+            } else {
+                // Otherwise, just use set() to change the existing value in the registry directly.
+                rawIdToEntry.set(id, object);
+            }
+
             entryToRawId.put(object.value(), id);
             if (nextId <= id) nextId = id + 1;
         }


### PR DESCRIPTION
This PR addresses a memory leak* during game load that has technically been present since the SimpleRegistry was added (and was even present in vanilla), but started manifesting out-of-the-box in StationAPI in 21b7a323fe3b880fed92bfaac0d611a33a60d832. 

## Background

The SimpleRegistry implementation locally tracks its set of raw IDs to references with a fastutil ReferenceArrayList, which has a default capacity of 256 entries:

```java
private final ReferenceList<Reference<T>> rawIdToEntry = new ReferenceArrayList<>(256);
```

When an element is added to the registry, the `set()` function ensures the `rawIdToEntry` map has sufficient capacity by calling `size(n)`:

```java
this.rawIdToEntry.size(Math.max(this.rawIdToEntry.size(), rawId + 1));
this.rawIdToEntry.set(rawId, reference);
```

This `size()` function is expensive, as it will create new instance of the backing array with the **exact** size requested, and call `System.arraycopy` to copy the elements. For one-off copies, this is fine, as it will eventually get garbage collected. However, if the function is repeatedly called, then once it reaches the capacity of 256 entries, it will allocate a new array **every** time, with memory growth bounded only by the JVM's `Xmx` value. It will happily use everything you give it without calling GC until absolutely necessary.

## Impact

This bug has been present in all versions of StationAPI that used this registry implementation, as well as in vanilla Minecraft in the version I checked (1.20.1). An installation with StationAPI with enough mods that register things would exhibit these same symptoms. The reason it starts to manifest out-of-the-box in 21b7a323fe3b880fed92bfaac0d611a33a60d832 is because the Stat registry is the first built-in registry to register more than 256 values. In fact, it immediately registers a value above id=256. Each call to register leads to full duplicates of the registry sitting around in memory until GC'd; I've observed it taking as much as 16 GB of memory in one go.

## Fix

Some time between 1.20.1 and 26.1, this was fixed in vanilla Minecraft by switching to the correct function for adding an entry: `ReferenceArrayList.add`:

```java
this.byKey.put(key, holder);
this.byLocation.put(key.identifier(), holder);
this.byValue.put(value, holder);
int newId = this.byId.size();
this.byId.add(holder); // <--- HERE
this.toId.put(value, newId);
this.registrationInfos.put(key, registrationInfo);
this.registryLifecycle = this.registryLifecycle.add(registrationInfo.lifecycle());
```

The [`add()`](<https://github.com/vigna/fastutil/blob/29fc48b416338ec9f626e878a45a89908b49b973/drv/ArrayList.drv#L495>) function here internally calls [`grow()`](<https://github.com/vigna/fastutil/blob/29fc48b416338ec9f626e878a45a89908b49b973/drv/ArrayList.drv#L474-L490>) (private in our version), which mimics ArrayList growth—the backing array is grown by **at least** 50% of the current capacity instead of by 1. This means that adding a 257th element to a 256-element array will grow it to at least 384 elements, leaving plenty of room for future additions and saving on expensive copies. The real memory impact of this extra capacity is negligible for registries.

The fix for StationAPI here is similar, but not identical. The new Minecraft `MappedRegistry` class no longer exposes `rawId` in `set`, so all adds are appends. To avoid impacting the rest of the StationAPI codebase, I opted to keep the API the same, and instead worked around the requirement for `rawId` in the implementation. This means `SimpleRegistry` will do one of three things when adding an element:

1. If the element is being added to the end (`rawId == size`), delegate directly to `.add()`, which will append it and call `grow()` if necessary.
2. If the element is being added further than the end (`rawId > size`, Stat does this), first fill the array with nulls up until the desired point, then `add()`. Both of these calls will call `grow()` internally, if necessary, but ideally only once. `Collections.nCopies` avoids actually allocating anything, keeping the memory impact negligible.
3. If the element is being added anywhere else (`rawId < size`), it is set directly as before.

## Testing

I have tested this fix in singleplayer in a development environment, multiplayer in a development environment, and singleplayer in a real modded environment. I have also run the test mod and ensured it worked correctly. I spot-checked most registries and everything seems to be behaving correctly. (for what it's worth, if it were misbehaving, it would crash catastrophically...) But I think it would be prudent to test further if possible.