### PR TITLE
Make events more consistent and add missing register methods

### DIFF
--- a/src/test/java/net/modificationstation/sltest/entity/EntityListener.java
+++ b/src/test/java/net/modificationstation/sltest/entity/EntityListener.java
@@ -1,7 +1,7 @@
 package net.modificationstation.sltest.entity;
 
 import net.mine_diver.unsafeevents.listener.EventListener;
-import net.modificationstation.stationapi.api.event.entity.EntityRegister;
+import net.modificationstation.stationapi.api.event.entity.EntityRegisterEvent;
 import net.modificationstation.stationapi.api.event.registry.EntityHandlerRegistryEvent;
 import net.modificationstation.stationapi.api.event.registry.MobHandlerRegistryEvent;
 
@@ -11,9 +11,9 @@ import static net.modificationstation.stationapi.api.util.Identifier.of;
 public class EntityListener {
 
     @EventListener
-    public void registerEntities(EntityRegister event) {
-        event.register(TestEntity.class, "sltest:test");
-        event.register(PoorGuy.class, "GPoor");
+    public void registerEntities(EntityRegisterEvent event) {
+        event.register("sltest:test", TestEntity.class);
+        event.register("GPoor", PoorGuy.class);
     }
 
     @EventListener

--- a/src/test/java/net/modificationstation/sltest/keyboard/KeyboardListener.java
+++ b/src/test/java/net/modificationstation/sltest/keyboard/KeyboardListener.java
@@ -3,6 +3,7 @@ package net.modificationstation.sltest.keyboard;
 import net.mine_diver.unsafeevents.listener.EventListener;
 import net.modificationstation.sltest.SLTest;
 import net.modificationstation.sltest.option.OptionListener;
+import net.modificationstation.sltest.packet.MineLMomentPacket;
 import net.modificationstation.stationapi.api.client.event.keyboard.KeyStateChangedEvent;
 import net.modificationstation.stationapi.api.network.packet.MessagePacket;
 import net.modificationstation.stationapi.api.network.packet.PacketHelper;
@@ -10,10 +11,16 @@ import net.modificationstation.stationapi.api.util.Identifier;
 import org.lwjgl.input.Keyboard;
 
 public class KeyboardListener {
-
     @EventListener
     public static void keyStateChange(KeyStateChangedEvent event) {
-        if (event.environment == KeyStateChangedEvent.Environment.IN_GAME && Keyboard.getEventKey() == OptionListener.testBind.code)
-            PacketHelper.send(new MessagePacket(Identifier.of(SLTest.NAMESPACE, "give_me_diamonds")));
+        if (event.environment == KeyStateChangedEvent.Environment.IN_GAME) {
+            if (Keyboard.getEventKey() == OptionListener.testBind.code) {
+                PacketHelper.send(new MessagePacket(Identifier.of(SLTest.NAMESPACE, "give_me_diamonds")));
+            }
+            
+            if (Keyboard.getEventKey() == OptionListener.mineLMoment.code) {
+                PacketHelper.send(new MineLMomentPacket(0));
+            }
+        }
     }
 }

--- a/src/test/java/net/modificationstation/sltest/option/OptionListener.java
+++ b/src/test/java/net/modificationstation/sltest/option/OptionListener.java
@@ -5,15 +5,16 @@ import net.fabricmc.api.Environment;
 import net.mine_diver.unsafeevents.listener.EventListener;
 import net.minecraft.client.option.KeyBinding;
 import net.modificationstation.stationapi.api.client.event.option.KeyBindingRegisterEvent;
+import org.lwjgl.input.Keyboard;
 
 public class OptionListener {
-
+    public static KeyBinding testBind;
+    public static KeyBinding mineLMoment;
+    
     @Environment(EnvType.CLIENT)
     @EventListener
     public void registerKeyBindings(KeyBindingRegisterEvent event) {
-        testBind = new KeyBinding("key.sltest.testBind", 21);
-        event.keyBindings.add(testBind);
+        event.register(testBind = new KeyBinding("key.sltest.testBind", 21));
+        event.register(mineLMoment = new KeyBinding("key.sltest.mine_l_moment", Keyboard.KEY_L));
     }
-
-    public static KeyBinding testBind;
 }

--- a/src/test/java/net/modificationstation/sltest/packet/MineLMomentPacket.java
+++ b/src/test/java/net/modificationstation/sltest/packet/MineLMomentPacket.java
@@ -1,0 +1,78 @@
+package net.modificationstation.sltest.packet;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.network.NetworkHandler;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.world.World;
+import net.modificationstation.stationapi.api.entity.player.PlayerHelper;
+import net.modificationstation.stationapi.api.network.packet.ManagedPacket;
+import net.modificationstation.stationapi.api.network.packet.PacketHelper;
+import net.modificationstation.stationapi.api.network.packet.PacketType;
+import net.modificationstation.stationapi.api.util.SideUtil;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+public class MineLMomentPacket extends Packet implements ManagedPacket<MineLMomentPacket> {
+    public static final PacketType<MineLMomentPacket> TYPE = PacketType.builder(true, true, MineLMomentPacket::new).build();
+    
+    int mineLMoments;
+
+    public MineLMomentPacket(int mineLMoments) {
+        this.mineLMoments = mineLMoments;
+    }
+
+    public MineLMomentPacket() {
+    }
+
+    @Override
+    public void read(DataInputStream stream) {
+        try {
+            mineLMoments = stream.readInt();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void write(DataOutputStream stream) {
+        try {
+            stream.writeInt(mineLMoments);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void apply(NetworkHandler networkHandler) {
+        SideUtil.run(() -> handleClient(networkHandler), () -> handleServer(networkHandler));
+    }
+
+    @Environment(EnvType.CLIENT)
+    public void handleClient(NetworkHandler networkHandler) {
+        PlayerEntity player = PlayerHelper.getPlayerFromPacketHandler(networkHandler);
+        player.sendMessage(mineLMoments + " Mine L Moments have occurred near you");
+    }
+
+    @Environment(EnvType.SERVER)
+    public void handleServer(NetworkHandler networkHandler) {
+        PlayerEntity player = PlayerHelper.getPlayerFromPacketHandler(networkHandler);
+        World world = player.world;
+
+        PacketHelper.sendToAllTracking(player, new MineLMomentPacket((int) world.getTime()));
+    }
+
+    @Override
+    public int size() {
+        return 4;
+    }
+
+    @Override
+    public @NotNull PacketType<MineLMomentPacket> getType() {
+        return TYPE;
+    }
+}

--- a/src/test/java/net/modificationstation/sltest/packet/PacketListener.java
+++ b/src/test/java/net/modificationstation/sltest/packet/PacketListener.java
@@ -1,0 +1,18 @@
+package net.modificationstation.sltest.packet;
+
+import net.mine_diver.unsafeevents.listener.EventListener;
+import net.modificationstation.stationapi.api.event.network.packet.PacketRegisterEvent;
+import net.modificationstation.stationapi.api.mod.entrypoint.Entrypoint;
+import net.modificationstation.stationapi.api.util.Namespace;
+
+@SuppressWarnings("unused")
+public class PacketListener {
+    @Entrypoint.Namespace
+    public static Namespace NAMESPACE;
+    
+    @EventListener
+    public void registerPackets(PacketRegisterEvent event) {
+        event.register(NAMESPACE.id("mine_l_moment"), MineLMomentPacket.TYPE);
+    }
+        
+}

--- a/src/test/java/net/modificationstation/sltest/tileentity/TileEntityListener.java
+++ b/src/test/java/net/modificationstation/sltest/tileentity/TileEntityListener.java
@@ -9,6 +9,6 @@ public class TileEntityListener {
     @EventListener
     public void registerTileEntities(BlockEntityRegisterEvent event) {
         SLTest.LOGGER.info("reeee tile entiites");
-        event.register(TileEntityFreezer.class, "sltest:freezer");
+        event.register("sltest:freezer", TileEntityFreezer.class);
     }
 }

--- a/src/test/resources/assets/sltest/stationapi/lang/en_US.lang
+++ b/src/test/resources/assets/sltest/stationapi/lang/en_US.lang
@@ -1,6 +1,7 @@
 item.@.test_item.name=Test Item
 item.@.model_item.name=IDK Something
 key.@.testBind=Diamonds!
+key.@.mine_l_moment=Mine L Moment
 tile.@.test_block.name=Test Block
 tile.@.test_animated_block0.name=Test Animated Block
 tile.@.test_animated_block1.name=Charged Animated Block

--- a/src/test/resources/fabric.mod.json
+++ b/src/test/resources/fabric.mod.json
@@ -33,7 +33,8 @@
       "net.modificationstation.sltest.worldgen.TestWorldgenListener",
       "net.modificationstation.sltest.bonemeal.BonemealListener",
       "net.modificationstation.sltest.dispenser.DispenserListener",
-      "net.modificationstation.sltest.effect.TestEffectListener"
+      "net.modificationstation.sltest.effect.TestEffectListener",
+      "net.modificationstation.sltest.packet.PacketListener"
     ],
     "stationapi:event_bus_client": [
       "net.modificationstation.sltest.gui.GuiListener",

--- a/station-blockentities-v0/src/main/java/net/modificationstation/stationapi/api/client/event/block/entity/BlockEntityRendererRegisterEvent.java
+++ b/station-blockentities-v0/src/main/java/net/modificationstation/stationapi/api/client/event/block/entity/BlockEntityRendererRegisterEvent.java
@@ -9,4 +9,8 @@ import java.util.Map;
 @SuperBuilder
 public class BlockEntityRendererRegisterEvent extends Event {
     public final Map<Class<? extends BlockEntity>, BlockEntityRenderer> renderers;
+    
+    public final void register(Class<? extends BlockEntity> blockEntityClass, BlockEntityRenderer renderer) {
+        renderers.put(blockEntityClass, renderer);
+    }
 }

--- a/station-blockentities-v0/src/main/java/net/modificationstation/stationapi/api/event/block/entity/BlockEntityRegisterEvent.java
+++ b/station-blockentities-v0/src/main/java/net/modificationstation/stationapi/api/event/block/entity/BlockEntityRegisterEvent.java
@@ -3,13 +3,19 @@ package net.modificationstation.stationapi.api.event.block.entity;
 import lombok.experimental.SuperBuilder;
 import net.mine_diver.unsafeevents.Event;
 import net.minecraft.block.entity.BlockEntity;
+import net.modificationstation.stationapi.api.util.Identifier;
+
 import java.util.function.BiConsumer;
 
 @SuperBuilder
 public class BlockEntityRegisterEvent extends Event {
     public final BiConsumer<Class<? extends BlockEntity>, String> register;
 
-    public final void register(Class<? extends BlockEntity> blockEntityClass, String id) {
+    public final void register(String id, Class<? extends BlockEntity> blockEntityClass) {
         register.accept(blockEntityClass, id);
+    }
+
+    public final void register(Identifier id, Class<? extends BlockEntity> blockEntityClass) {
+        register.accept(blockEntityClass, id.toString());
     }
 }

--- a/station-entities-v0/src/main/java/net/modificationstation/stationapi/api/event/entity/EntityRegisterEvent.java
+++ b/station-entities-v0/src/main/java/net/modificationstation/stationapi/api/event/entity/EntityRegisterEvent.java
@@ -3,9 +3,10 @@ package net.modificationstation.stationapi.api.event.entity;
 import lombok.experimental.SuperBuilder;
 import net.mine_diver.unsafeevents.Event;
 import net.minecraft.entity.Entity;
+import net.modificationstation.stationapi.api.util.Identifier;
 
 @SuperBuilder
-public class EntityRegister extends Event {
+public class EntityRegisterEvent extends Event {
     @FunctionalInterface
     public interface RegisterFunction {
         void register(Class<? extends Entity> entityClass, String entityIdentifier, int entityId);
@@ -19,11 +20,15 @@ public class EntityRegister extends Event {
     public final RegisterFunction register;
     public final RegisterFunctionNoId registerNoID;
 
-    public final void register(Class<? extends Entity> entityClass, String entityIdentifier, int entityId) {
+    public final void register(String entityIdentifier, int entityId, Class<? extends Entity> entityClass) {
         register.register(entityClass, entityIdentifier, entityId);
     }
 
-    public final void register(Class<? extends Entity> entityClass, String entityIdentifier) {
+    public final void register(String entityIdentifier, Class<? extends Entity> entityClass) {
         registerNoID.register(entityClass, entityIdentifier);
+    }
+    
+    public final void register(Identifier entityIdentifier, Class<? extends Entity> entityClass) {
+        registerNoID.register(entityClass, entityIdentifier.toString());
     }
 }

--- a/station-entities-v0/src/main/java/net/modificationstation/stationapi/mixin/entity/EntityRegistryMixin.java
+++ b/station-entities-v0/src/main/java/net/modificationstation/stationapi/mixin/entity/EntityRegistryMixin.java
@@ -3,7 +3,7 @@ package net.modificationstation.stationapi.mixin.entity;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityRegistry;
 import net.modificationstation.stationapi.api.StationAPI;
-import net.modificationstation.stationapi.api.event.entity.EntityRegister;
+import net.modificationstation.stationapi.api.event.entity.EntityRegisterEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,7 +24,7 @@ class EntityRegistryMixin {
     @Inject(method = "<clinit>", at = @At("RETURN"))
     private static void stationapi_onEntityRegister(CallbackInfo ci) {
         StationAPI.EVENT_BUS.post(
-                EntityRegister.builder()
+                EntityRegisterEvent.builder()
                         .register(EntityRegistryMixin::register)
                         .registerNoID((aClass, s) -> {
                             idToClass.put(s, aClass);

--- a/station-keybindings-v0/src/main/java/net/modificationstation/stationapi/api/client/event/option/KeyBindingRegisterEvent.java
+++ b/station-keybindings-v0/src/main/java/net/modificationstation/stationapi/api/client/event/option/KeyBindingRegisterEvent.java
@@ -20,4 +20,8 @@ import java.util.List;
 @SuperBuilder
 public class KeyBindingRegisterEvent extends Event {
     public final List<KeyBinding> keyBindings;
+    
+    public final void register(KeyBinding keyBinding) {
+        keyBindings.add(keyBinding);
+    }
 }

--- a/station-networking-v0/src/main/java/net/modificationstation/stationapi/api/event/network/packet/PacketRegisterEvent.java
+++ b/station-networking-v0/src/main/java/net/modificationstation/stationapi/api/event/network/packet/PacketRegisterEvent.java
@@ -6,6 +6,10 @@ import net.mine_diver.unsafeevents.event.EventPhases;
 import net.minecraft.network.packet.Packet;
 import net.modificationstation.stationapi.api.StationAPI;
 import net.modificationstation.stationapi.api.network.packet.MessagePacket;
+import net.modificationstation.stationapi.api.network.packet.PacketType;
+import net.modificationstation.stationapi.api.registry.PacketTypeRegistry;
+import net.modificationstation.stationapi.api.registry.Registry;
+import net.modificationstation.stationapi.api.util.Identifier;
 
 /**
  * Event that fires after vanilla packets are registered.
@@ -33,15 +37,25 @@ public class PacketRegisterEvent extends Event implements PacketRegister {
      *
      * <p>Uses {@link PacketRegisterEvent#register} field to process the registration.
      *
-     * @param packetId the packet ID that you want to use for the packet.
-     *                 The ID is written as a byte, meaning it can be any number in the 0-255 (inclusive) range,
-     *                 except for already taken packet IDs.
+     * @param packetId           the packet ID that you want to use for the packet.
+     *                           The ID is written as a byte, meaning it can be any number in the 0-255 (inclusive) range,
+     *                           except for already taken packet IDs.
      * @param receivableOnClient whether this packet is supposed to be received on the client side.
      * @param receivableOnServer whether this packet is supposed to be received on the server side.
-     * @param packetClass the packet's class that extends {@link Packet} or a sub class of it.
+     * @param packetClass        the packet's class that extends {@link Packet} or a sub class of it.
      */
     @Override
     public final void register(int packetId, boolean receivableOnClient, boolean receivableOnServer, Class<? extends Packet> packetClass) {
         register.register(packetId, receivableOnClient, receivableOnServer, packetClass);
+    }
+
+    /**
+     * Registers the given {@link PacketType}
+     *
+     * @param id         The identifier of the packet
+     * @param packetType The packet type of the packet
+     */
+    public final void register(Identifier id, PacketType<? extends Packet> packetType) {
+        Registry.register(PacketTypeRegistry.INSTANCE, id, packetType);
     }
 }

--- a/station-networking-v0/src/main/java/net/modificationstation/stationapi/mixin/network/PacketMixin.java
+++ b/station-networking-v0/src/main/java/net/modificationstation/stationapi/mixin/network/PacketMixin.java
@@ -7,12 +7,10 @@ import net.modificationstation.stationapi.api.StationAPI;
 import net.modificationstation.stationapi.api.event.network.packet.PacketRegisterEvent;
 import net.modificationstation.stationapi.api.network.packet.ManagedPacket;
 import net.modificationstation.stationapi.api.registry.PacketTypeRegistry;
-import net.modificationstation.stationapi.api.util.Null;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 


### PR DESCRIPTION
* Renamed `EntityRegister` to `EntityRegisterEvent`
* Added a `KeyBindingRegisterEvent.register` method
* Added a `BlockEntityRendererRegisterEvent.register` method
* Added a `BlockEntityRegisterEvent.register` overload using `Identifier`
* Added a `EntityRegisterEvent.register` overload using Identifier
* Added a `PacketRegisterEvent.register` method which accepts PacketType
* Unified some events to use the `Identifier, <register object>` order in the register methods in accordance to register methods already using Identifiers.

It might be worth considering removing the String id register methods completely from stuff like entities and block entities

The funciton of the packet type registering tested using a an added test mod packet, everything else is pretty much helper methods
<img width="2047" height="1279" alt="obrazek" src="https://github.com/user-attachments/assets/0d77fadf-2ece-43f5-b55f-dc7ceefb3d76" />