### PR TITLE
chore: update DFU to v9

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,14 @@ allprojects {
         maven(url = "https://maven.glass-launcher.net/snapshots")
         maven(url = "https://maven.glass-launcher.net/releases")
         maven(url = "https://jitpack.io/")
+
+        maven("https://libraries.minecraft.net") {
+            name = "Mojang"
+            content {
+                includeModule("com.mojang", "datafixerupper") // https://github.com/Mojang/DataFixerUpper
+            }
+        }
+
         mavenCentral()
         exclusiveContent {
             forRepository {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ fabric.loom.multiProjectOptimisation=true
     unsafeevents_version = e31096e
     fastutil_version = 8.5.8
     caffeine_version = 3.0.5
-    dfu_version = 6.0.6
+    dfu_version = 9.1.20
     spasm_version = 0.2.2
 
 # Mod Properties

--- a/station-flattening-v0/src/main/java/net/modificationstation/stationapi/api/state/State.java
+++ b/station-flattening-v0/src/main/java/net/modificationstation/stationapi/api/state/State.java
@@ -146,7 +146,7 @@ public abstract class State<O, S> {
     protected static <O, S extends State<O, S>> Codec<S> createCodec(Codec<O> codec, Function<O, S> ownerToStateFunction) {
         return codec.dispatch("Name", (state) -> state.owner, (object) -> {
             S state = ownerToStateFunction.apply(object);
-            return state.getEntries().isEmpty() ? Codec.unit(state) : state.codec.fieldOf("Properties").codec();
+            return state.getEntries().isEmpty() ? MapCodec.unit(state) : state.codec.fieldOf("Properties");
         });
     }
 }

--- a/station-flattening-v0/src/main/java/net/modificationstation/stationapi/impl/world/FlattenedWorldManager.java
+++ b/station-flattening-v0/src/main/java/net/modificationstation/stationapi/impl/world/FlattenedWorldManager.java
@@ -45,7 +45,7 @@ public class FlattenedWorldManager {
             if (!ChunkSection.isEmpty(section)) {
                 NbtCompound sectionTag = new NbtCompound();
                 sectionTag.putByte(HEIGHT_KEY, (byte)sectionY);
-                sectionTag.put("block_states", CODEC.encodeStart(NbtOps.INSTANCE, section.getBlockStateContainer()).getOrThrow(false, LOGGER::error));
+                sectionTag.put("block_states", CODEC.encodeStart(NbtOps.INSTANCE, section.getBlockStateContainer()).getOrThrow());
                 sectionTag.put(METADATA_KEY, section.getMetadataArray().toTag());
                 sectionTag.put(SKY_LIGHT_KEY, section.getLightArray(LightType.SKY).toTag());
                 sectionTag.put(BLOCK_LIGHT_KEY, section.getLightArray(LightType.BLOCK).toTag());
@@ -87,7 +87,7 @@ public class FlattenedWorldManager {
                 int sectionY = sectionTag.getByte(HEIGHT_KEY);
                 int index = world.sectionCoordToIndex(sectionY);
                 if (index < 0 || index >= sections.length) continue;
-                PalettedContainer<BlockState> blockStates = sectionTag.contains("block_states") ? CODEC.parse(NbtOps.INSTANCE, sectionTag.getCompound("block_states")).promotePartial(errorMessage -> logRecoverableError(xPos, zPos, sectionY, errorMessage)).getOrThrow(false, LOGGER::error) : new PalettedContainer<>(Block.STATE_IDS, States.AIR.get(), PalettedContainer.PaletteProvider.BLOCK_STATE);
+                PalettedContainer<BlockState> blockStates = sectionTag.contains("block_states") ? CODEC.parse(NbtOps.INSTANCE, sectionTag.getCompound("block_states")).promotePartial(errorMessage -> logRecoverableError(xPos, zPos, sectionY, errorMessage)).getOrThrow() : new PalettedContainer<>(Block.STATE_IDS, States.AIR.get(), PalettedContainer.PaletteProvider.BLOCK_STATE);
                 ChunkSection chunkSection = new ChunkSection(sectionY, blockStates);
                 chunkSection.getMetadataArray().copyArray(sectionTag.getByteArray(METADATA_KEY));
                 chunkSection.getLightArray(LightType.SKY).copyArray(sectionTag.getByteArray(SKY_LIGHT_KEY));

--- a/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/registry/RegistryLoader.java
+++ b/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/registry/RegistryLoader.java
@@ -91,7 +91,7 @@ public class RegistryLoader {
             try (BufferedReader reader = resource.getReader()) {
                 JsonElement jsonElement = JsonParser.parseReader(reader);
                 DataResult<E> dataResult = decoder.parse(registryOps, jsonElement);
-                E object = dataResult.getOrThrow(false, error -> {});
+                E object = dataResult.getOrThrow();
                 newRegistry.add(registryKey, object, resource.isAlwaysStable() ? Lifecycle.stable() : dataResult.lifecycle());
             } catch (Exception exception) {
                 exceptions.put(registryKey, new IllegalStateException(String.format(Locale.ROOT, "Failed to parse %s from pack %s", identifier, resource.getResourcePackName()), exception));

--- a/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/tag/TagGroupLoader.java
+++ b/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/tag/TagGroupLoader.java
@@ -17,7 +17,6 @@ import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
 import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.resource.Resource;
 import net.modificationstation.stationapi.api.resource.ResourceManager;
-import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.Reader;

--- a/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/tag/TagGroupLoader.java
+++ b/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/tag/TagGroupLoader.java
@@ -55,9 +55,7 @@ public class TagGroupLoader<T> {
                         JsonElement jsonElement = JsonParser.parseReader(reader);
                         List<TrackedEntry> list = map.computeIfAbsent(identifier2, identifierx -> new ArrayList<>());
                         DataResult<TagFile> var10000 = TagFile.CODEC.parse(new Dynamic<>(JsonOps.INSTANCE, jsonElement));
-                        Logger var10002 = LOGGER;
-                        Objects.requireNonNull(var10002);
-                        TagFile tagFile = var10000.getOrThrow(false, var10002::error);
+                        TagFile tagFile = var10000.getOrThrow();
                         if (tagFile.replace()) list.clear();
 
                         String string2 = resource.getResourcePackName();

--- a/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/util/dynamic/EntryLoader.java
+++ b/station-registry-api-v0/src/main/java/net/modificationstation/stationapi/api/util/dynamic/EntryLoader.java
@@ -130,7 +130,7 @@ public interface EntryLoader {
 
         public <E> void add(DynamicRegistryManager registryManager, RegistryKey<E> key, Encoder<E> encoder, int rawId, E entry, Lifecycle lifecycle) {
             DataResult<JsonElement> dataResult = encoder.encodeStart(RegistryOps.of(JsonOps.INSTANCE, registryManager), entry);
-            Optional<DataResult.PartialResult<JsonElement>> optional = dataResult.error();
+            Optional<DataResult.Error<JsonElement>> optional = dataResult.error();
             if (optional.isPresent()) {
                 LOGGER.error("Error adding element: {}", optional.get().message());
             } else {

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/AtlasLoader.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/AtlasLoader.java
@@ -64,7 +64,7 @@ public class AtlasLoader {
         ArrayList<AtlasSource> list = new ArrayList<>();
         for (Resource resource : resourceManager.getAllResources(identifier))
             try (BufferedReader bufferedReader = resource.getReader()) {
-                list.addAll(AtlasSourceManager.LIST_CODEC.parse(new Dynamic<>(JsonOps.INSTANCE, JsonParser.parseReader(bufferedReader))).getOrThrow(false, LOGGER::error));
+                list.addAll(AtlasSourceManager.LIST_CODEC.parse(new Dynamic<>(JsonOps.INSTANCE, JsonParser.parseReader(bufferedReader))).getOrThrow());
             } catch (Exception exception) {
                 LOGGER.warn("Failed to parse atlas definition {} in pack {}", identifier, "Default", exception);
             }

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/AtlasSourceManager.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/AtlasSourceManager.java
@@ -4,6 +4,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
+import com.mojang.serialization.MapCodec;
 import net.modificationstation.stationapi.api.util.Identifier;
 
 import java.util.List;
@@ -25,7 +26,7 @@ public class AtlasSourceManager {
     public static Codec<AtlasSource> TYPE_CODEC = CODEC.dispatch(AtlasSource::getType, AtlasSourceType::codec);
     public static Codec<List<AtlasSource>> LIST_CODEC = TYPE_CODEC.listOf().fieldOf("sources").codec();
 
-    private static AtlasSourceType register(String id, Codec<? extends AtlasSource> codec) {
+    private static AtlasSourceType register(String id, MapCodec<? extends AtlasSource> codec) {
         Identifier identifier = Identifier.of(id);
         AtlasSourceType atlasSourceType = new AtlasSourceType(codec);
         AtlasSourceType atlasSourceType2 = SOURCE_TYPE_BY_ID.putIfAbsent(identifier, atlasSourceType);

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/AtlasSourceType.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/AtlasSourceType.java
@@ -1,6 +1,6 @@
 package net.modificationstation.stationapi.api.client.texture.atlas;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 
-public record AtlasSourceType(Codec<? extends AtlasSource> codec) {}
+public record AtlasSourceType(MapCodec<? extends AtlasSource> codec) {}
 

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/DirectoryAtlasSource.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/DirectoryAtlasSource.java
@@ -1,6 +1,7 @@
 package net.modificationstation.stationapi.api.client.texture.atlas;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.modificationstation.stationapi.api.resource.ResourceFinder;
 import net.modificationstation.stationapi.api.resource.ResourceManager;
@@ -8,7 +9,7 @@ import net.modificationstation.stationapi.api.resource.ResourceManager;
 import static net.modificationstation.stationapi.api.StationAPI.NAMESPACE;
 
 public class DirectoryAtlasSource implements AtlasSource {
-    public static final Codec<DirectoryAtlasSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(Codec.STRING.fieldOf("source").forGetter(directoryAtlasSource -> directoryAtlasSource.source), Codec.STRING.fieldOf("prefix").forGetter(directoryAtlasSource -> directoryAtlasSource.prefix)).apply(instance, DirectoryAtlasSource::new));
+    public static final MapCodec<DirectoryAtlasSource> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(Codec.STRING.fieldOf("source").forGetter(directoryAtlasSource -> directoryAtlasSource.source), Codec.STRING.fieldOf("prefix").forGetter(directoryAtlasSource -> directoryAtlasSource.prefix)).apply(instance, DirectoryAtlasSource::new));
     private final String source;
     private final String prefix;
 

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/FilterAtlasSource.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/FilterAtlasSource.java
@@ -1,12 +1,12 @@
 package net.modificationstation.stationapi.api.client.texture.atlas;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.modificationstation.stationapi.api.resource.ResourceManager;
 import net.modificationstation.stationapi.api.resource.metadata.BlockEntry;
 
 public class FilterAtlasSource implements AtlasSource {
-    public static final Codec<FilterAtlasSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(BlockEntry.CODEC.fieldOf("pattern").forGetter(filterAtlasSource -> filterAtlasSource.pattern)).apply(instance, FilterAtlasSource::new));
+    public static final MapCodec<FilterAtlasSource> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(BlockEntry.CODEC.fieldOf("pattern").forGetter(filterAtlasSource -> filterAtlasSource.pattern)).apply(instance, FilterAtlasSource::new));
     private final BlockEntry pattern;
 
     public FilterAtlasSource(BlockEntry pattern) {

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/PalettedPermutationsAtlasSource.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/PalettedPermutationsAtlasSource.java
@@ -3,15 +3,16 @@ package net.modificationstation.stationapi.api.client.texture.atlas;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 import net.modificationstation.stationapi.api.client.resource.metadata.AnimationResourceMetadata;
 import net.modificationstation.stationapi.api.client.texture.NativeImage;
 import net.modificationstation.stationapi.api.client.texture.SpriteContents;
 import net.modificationstation.stationapi.api.client.texture.SpriteDimensions;
-import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.resource.Resource;
 import net.modificationstation.stationapi.api.resource.ResourceManager;
+import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.util.math.ColorHelper;
 import org.jetbrains.annotations.Nullable;
 
@@ -26,7 +27,7 @@ import java.util.function.IntUnaryOperator;
 import static net.modificationstation.stationapi.impl.client.texture.StationRenderImpl.LOGGER;
 
 public class PalettedPermutationsAtlasSource implements AtlasSource {
-    public static final Codec<PalettedPermutationsAtlasSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(Codec.list(Identifier.CODEC).fieldOf("textures").forGetter(palettedPermutationsAtlasSource -> palettedPermutationsAtlasSource.textures), Identifier.CODEC.fieldOf("palette_key").forGetter(palettedPermutationsAtlasSource -> palettedPermutationsAtlasSource.paletteKey), Codec.unboundedMap(Codec.STRING, Identifier.CODEC).fieldOf("permutations").forGetter(palettedPermutationsAtlasSource -> palettedPermutationsAtlasSource.permutations)).apply(instance, PalettedPermutationsAtlasSource::new));
+    public static final MapCodec<PalettedPermutationsAtlasSource> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(Codec.list(Identifier.CODEC).fieldOf("textures").forGetter(palettedPermutationsAtlasSource -> palettedPermutationsAtlasSource.textures), Identifier.CODEC.fieldOf("palette_key").forGetter(palettedPermutationsAtlasSource -> palettedPermutationsAtlasSource.paletteKey), Codec.unboundedMap(Codec.STRING, Identifier.CODEC).fieldOf("permutations").forGetter(palettedPermutationsAtlasSource -> palettedPermutationsAtlasSource.permutations)).apply(instance, PalettedPermutationsAtlasSource::new));
     private final List<Identifier> textures;
     private final Map<String, Identifier> permutations;
     private final Identifier paletteKey;

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/SingleAtlasSource.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/SingleAtlasSource.java
@@ -1,17 +1,17 @@
 package net.modificationstation.stationapi.api.client.texture.atlas;
 
-import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
-import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.resource.Resource;
 import net.modificationstation.stationapi.api.resource.ResourceManager;
+import net.modificationstation.stationapi.api.util.Identifier;
 
 import java.util.Optional;
 
 import static net.modificationstation.stationapi.impl.client.texture.StationRenderImpl.LOGGER;
 
 public class SingleAtlasSource implements AtlasSource {
-    public static final Codec<SingleAtlasSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(Identifier.CODEC.fieldOf("resource").forGetter(singleAtlasSource -> singleAtlasSource.resource), Identifier.CODEC.optionalFieldOf("sprite").forGetter(singleAtlasSource -> singleAtlasSource.sprite)).apply(instance, SingleAtlasSource::new));
+    public static final MapCodec<SingleAtlasSource> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(Identifier.CODEC.fieldOf("resource").forGetter(singleAtlasSource -> singleAtlasSource.resource), Identifier.CODEC.optionalFieldOf("sprite").forGetter(singleAtlasSource -> singleAtlasSource.sprite)).apply(instance, SingleAtlasSource::new));
     private final Identifier resource;
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private final Optional<Identifier> sprite;

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/UnstitchAtlasSource.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/texture/atlas/UnstitchAtlasSource.java
@@ -1,6 +1,7 @@
 package net.modificationstation.stationapi.api.client.texture.atlas;
 
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.util.math.MathHelper;
 import net.modificationstation.stationapi.api.client.resource.metadata.AnimationResourceMetadata;
@@ -8,9 +9,9 @@ import net.modificationstation.stationapi.api.client.texture.MissingSprite;
 import net.modificationstation.stationapi.api.client.texture.NativeImage;
 import net.modificationstation.stationapi.api.client.texture.SpriteContents;
 import net.modificationstation.stationapi.api.client.texture.SpriteDimensions;
-import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.resource.Resource;
 import net.modificationstation.stationapi.api.resource.ResourceManager;
+import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.util.dynamic.Codecs;
 
 import java.util.List;
@@ -19,7 +20,7 @@ import java.util.Optional;
 import static net.modificationstation.stationapi.impl.client.texture.StationRenderImpl.LOGGER;
 
 public class UnstitchAtlasSource implements AtlasSource {
-    public static final Codec<UnstitchAtlasSource> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+    public static final MapCodec<UnstitchAtlasSource> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             Identifier.CODEC.fieldOf("resource").forGetter(unstitchAtlasSource -> unstitchAtlasSource.resource),
             Codecs.nonEmptyList(Region.CODEC.listOf()).fieldOf("regions").forGetter(unstitchAtlasSource -> unstitchAtlasSource.regions),
             Codec.DOUBLE.optionalFieldOf("divisor_x", 1.0).forGetter(unstitchAtlasSource -> unstitchAtlasSource.divisorX),

--- a/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/api/resource/metadata/ResourceMetadataSerializer.java
+++ b/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/api/resource/metadata/ResourceMetadataSerializer.java
@@ -18,12 +18,12 @@ public interface ResourceMetadataSerializer<T> extends ResourceMetadataReader<T>
 
             @Override
             public T fromJson(JsonObject json) {
-                return codec.parse(JsonOps.INSTANCE, json).getOrThrow(false, error -> {});
+                return codec.parse(JsonOps.INSTANCE, json).getOrThrow();
             }
 
             @Override
             public JsonObject toJson(T metadata) {
-                return codec.encodeStart(JsonOps.INSTANCE, metadata).getOrThrow(false, error -> {}).getAsJsonObject();
+                return codec.encodeStart(JsonOps.INSTANCE, metadata).getOrThrow().getAsJsonObject();
             }
         };
     }

--- a/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/impl/resource/DefaultResourcePack.java
+++ b/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/impl/resource/DefaultResourcePack.java
@@ -1,5 +1,6 @@
 package net.modificationstation.stationapi.impl.resource;
 
+import com.mojang.serialization.DataResult;
 import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
 import lombok.val;
 import net.modificationstation.stationapi.api.util.Identifier;
@@ -51,24 +52,30 @@ public class DefaultResourcePack implements ResourcePack {
 
     @Override
     public @Nullable InputSupplier<InputStream> open(ResourceType type, Identifier id) {
-        return PathUtil.split(id.path).get().map(segments -> {
+        var result = PathUtil.split(id.path);
+
+        if (result.isSuccess()) {
+            var segments = result.getOrThrow();
             String string = id.namespace.toString();
             if (NAMESPACE_PATHS.containsKey(type)) for (Path path : NAMESPACE_PATHS.get(type)) {
                 Path path2 = PathUtil.getPath(path.resolve(string), segments);
                 if (!Files.exists(path2) || !DirectoryResourcePack.isValidPath(path2)) continue;
                 return InputSupplier.create(path2);
             }
-            return null;
-        }, result -> {
-            LOGGER.error("Invalid path {}: {}", id, result.message());
-            return null;
-        });
+        } else {
+            LOGGER.error("Invalid path {}: {}", id, result.error().map(DataResult.Error::message));
+        }
+
+        return null;
     }
 
     @Override
     public void findResources(ResourceType type, Namespace namespace, String prefix, ResultConsumer consumer) {
         val atRoot = prefix.startsWith("/");
-        PathUtil.split(atRoot ? prefix.substring(1) : prefix).get().ifLeft(segments -> {
+        var result = PathUtil.split(atRoot ? prefix.substring(1) : prefix);
+
+        if (result.isSuccess()) {
+            var segments = result.getOrThrow();
             final List<Path> paths;
             if (namespace == Namespace.MINECRAFT && atRoot) {
                 paths = ROOT_PATHS;
@@ -88,7 +95,9 @@ public class DefaultResourcePack implements ResourcePack {
                     map.forEach(consumer);
                 }
             }
-        }).ifRight(result -> LOGGER.error("Invalid path {}: {}", prefix, result.message()));
+        } else {
+            LOGGER.error("Invalid path {}: {}", prefix, result.error().map(DataResult.Error::message));
+        }
     }
 
     private static void collectIdentifiers(ResultConsumer consumer, Namespace namespace, Path root, List<String> prefixSegments, boolean atRoot) {

--- a/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/impl/resource/DirectoryResourcePack.java
+++ b/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/impl/resource/DirectoryResourcePack.java
@@ -2,6 +2,7 @@ package net.modificationstation.stationapi.impl.resource;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Sets;
+import com.mojang.serialization.DataResult;
 import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.util.Namespace;
 import net.modificationstation.stationapi.api.resource.InputSupplier;
@@ -56,13 +57,16 @@ public class DirectoryResourcePack extends AbstractFileResourcePack {
     }
 
     public static InputSupplier<InputStream> open(Identifier id, Path path) {
-        return PathUtil.split(id.path).get().map(segments -> {
+        var result = PathUtil.split(id.path);
+
+        if (result.isSuccess()) {
+            var segments = result.getOrThrow();
             Path path2 = PathUtil.getPath(path, segments);
             return DirectoryResourcePack.open(path2);
-        }, result -> {
-            LOGGER.error("Invalid path {}: {}", id, result.message());
+        } else {
+            LOGGER.error("Invalid path {}: {}", id, result.error().map(DataResult.Error::message));
             return null;
-        });
+        }
     }
 
     @Nullable
@@ -75,10 +79,15 @@ public class DirectoryResourcePack extends AbstractFileResourcePack {
 
     @Override
     public void findResources(ResourceType type, Namespace namespace, String prefix, ResourcePack.ResultConsumer consumer) {
-        PathUtil.split(prefix).get().ifLeft(prefixSegments -> {
+        var result = PathUtil.split(prefix);
+
+        if (result.isSuccess()) {
+            var prefixSegments = result.getOrThrow();
             Path path = this.root.resolve(type.getDirectory()).resolve(namespace.toString());
             DirectoryResourcePack.findResources(namespace, path, prefixSegments, consumer);
-        }).ifRight(result -> LOGGER.error("Invalid path {}: {}", prefix, result.message()));
+        } else {
+            LOGGER.error("Invalid path {}: {}", prefix, result.error().map(DataResult.Error::message));
+        }
     }
 
     public static void findResources(Namespace namespace, Path path, List<String> prefixSegments, ResourcePack.ResultConsumer consumer) {

--- a/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/impl/resource/NamespaceResourceManager.java
+++ b/station-resource-loader-v0/src/main/java/net/modificationstation/stationapi/impl/resource/NamespaceResourceManager.java
@@ -52,7 +52,7 @@ public class NamespaceResourceManager implements ResourceManager {
 
     private Function<ResourcePack, InputSupplier<InputStream>> createOpener(Identifier id) {
         if (id.namespace == Namespace.MINECRAFT && id.path.startsWith("/")) {
-            final String[] segments = PathUtil.split(id.path.substring(1)).getOrThrow(false, LOGGER::error).toArray(String[]::new);
+            final String[] segments = PathUtil.split(id.path.substring(1)).getOrThrow().toArray(String[]::new);
             return pack -> pack.openRoot(segments.clone());
         } else return pack -> pack.open(type, id);
     }

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/impl/vanillafix/datafixer/VanillaDataFixerImpl.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/impl/vanillafix/datafixer/VanillaDataFixerImpl.java
@@ -7,12 +7,10 @@ import com.mojang.datafixers.schemas.Schema;
 import net.mine_diver.unsafeevents.listener.EventListener;
 import net.modificationstation.stationapi.api.StationAPI;
 import net.modificationstation.stationapi.api.datafixer.DataFixers;
-import net.modificationstation.stationapi.api.datafixer.TypeReferences;
 import net.modificationstation.stationapi.api.event.datafixer.DataFixerRegisterEvent;
 import net.modificationstation.stationapi.api.mod.entrypoint.Entrypoint;
 import net.modificationstation.stationapi.api.mod.entrypoint.EntrypointManager;
 import net.modificationstation.stationapi.api.mod.entrypoint.EventBusPolicy;
-import net.modificationstation.stationapi.api.util.Util;
 import net.modificationstation.stationapi.api.vanillafix.datadamager.damage.StationFlatteningToMcRegionChunkDamage;
 import net.modificationstation.stationapi.api.vanillafix.datadamager.damage.StationFlatteningToMcRegionItemStackDamage;
 import net.modificationstation.stationapi.api.vanillafix.datadamager.schema.McRegionChunkDamagerSchema;
@@ -25,7 +23,6 @@ import net.modificationstation.stationapi.api.vanillafix.datafixer.schema.Statio
 import net.modificationstation.stationapi.api.vanillafix.datafixer.schema.StationFlatteningItemStackSchema;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import static net.modificationstation.stationapi.api.StationAPI.NAMESPACE;

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/impl/vanillafix/datafixer/VanillaDataFixerImpl.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/impl/vanillafix/datafixer/VanillaDataFixerImpl.java
@@ -48,7 +48,7 @@ public final class VanillaDataFixerImpl {
         builder.addFixer(new StationFlatteningToMcRegionChunkDamage(schema69420, "StationFlatteningToMcRegionChunkDamage"));
         Schema schema19132 = builder.addSchema(VANILLA_VERSION, McRegionItemStackDamagerSchema::new);
         builder.addFixer(new StationFlatteningToMcRegionItemStackDamage(schema19132, "StationFlatteningToMcRegionItemStackDamage"));
-        return builder.buildOptimized(Set.of(TypeReferences.LEVEL), Util.getBootstrapExecutor());
+        return builder.build().fixer();
     });
 
     @EventListener
@@ -60,7 +60,7 @@ public final class VanillaDataFixerImpl {
             builder.addFixer(new McRegionToStationFlatteningItemStackFix(schema69420, "McRegionToStationFlatteningItemStackFix"));
             Schema schema69421 = builder.addSchema(69421, StationFlatteningChunkSchema::new);
             builder.addFixer(new McRegionToStationFlatteningChunkFix(schema69421, "McRegionToStationFlatteningChunkFix"));
-            return builder.buildOptimized(Set.of(TypeReferences.LEVEL), executor);
+            return builder.build().fixer();
         }, CURRENT_VERSION);
     }
 }


### PR DESCRIPTION
sorry in advance... i'm not 100% sure the changes here are correct, especially with changing atlases to a MapCodec and with removing the optimize calls in DFU. looking at 26.1 code, DFU calls optimize once at startup but only on the LEVEL_SUMMARY/LIGHTWEIGHT_LEVEL reference type. it's a bit over my head!

but it does compile and run :) 