### PR TITLE
Fix integer overflow in StationTessellatorImpl buffer growth

### DIFF
--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/impl/client/render/StationTessellatorImpl.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/impl/client/render/StationTessellatorImpl.java
@@ -17,6 +17,12 @@ import static net.modificationstation.stationapi.impl.client.texture.StationRend
 
 public class StationTessellatorImpl implements StationTessellator {
 
+    // Hard ceiling on the int-buffer size so it can never grow large enough for
+    // bufferSize * 4 (the byte-buffer allocation) to overflow a signed int.
+    // 2^28 ints = 1 GiB direct buffer, far beyond anything vanilla rendering needs;
+    // the buffer base size is 2^21 ints, so this still allows several doublings.
+    private static final int MAX_BUFFER_SIZE = 1 << 28;
+
     private final Tessellator self;
     private final TessellatorAccessor access;
     private final int[] fastVertexData = new int[32];
@@ -103,11 +109,19 @@ public class StationTessellatorImpl implements StationTessellator {
 
     @Override
     public void ensureBufferCapacity(int criticalCapacity) {
-        if (access.stationapi$getBufferPosition() >= access.stationapi$getBufferSize() - criticalCapacity) {
-            LOGGER.info("Tessellator is nearing its maximum capacity. Increasing the buffer size from {} to {}", access.stationapi$getBufferSize(), access.stationapi$getBufferSize() * 2);
-            access.stationapi$setBufferSize(access.stationapi$getBufferSize() * 2);
-            access.stationapi$setBuffer(Arrays.copyOf(access.stationapi$getBuffer(), access.stationapi$getBufferSize()));
-            ByteBuffer newBuffer = GlAllocationUtils.allocateByteBuffer(access.stationapi$getBufferSize() * 4);
+        int bufferSize = access.stationapi$getBufferSize();
+        if (access.stationapi$getBufferPosition() >= bufferSize - criticalCapacity) {
+            if (bufferSize >= MAX_BUFFER_SIZE) {
+                // Already at the ceiling; doubling further would overflow bufferSize * 4.
+                // Leave the buffer as-is rather than allocating an invalid (negative) capacity.
+                return;
+            }
+            int newBufferSize = Math.min(bufferSize * 2, MAX_BUFFER_SIZE);
+            LOGGER.info("Tessellator is nearing its maximum capacity. Increasing the buffer size from {} to {}", bufferSize, newBufferSize);
+            access.stationapi$setBufferSize(newBufferSize);
+            access.stationapi$setBuffer(Arrays.copyOf(access.stationapi$getBuffer(), newBufferSize));
+            // long arithmetic so the byte count can never overflow a signed int.
+            ByteBuffer newBuffer = GlAllocationUtils.allocateByteBuffer((int) ((long) newBufferSize * 4));
             access.stationapi$setByteBuffer(newBuffer);
             access.stationapi$setIntBuffer(newBuffer.asIntBuffer());
             access.stationapi$setFloatBuffer(newBuffer.asFloatBuffer());

--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/impl/client/render/StationTessellatorImpl.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/impl/client/render/StationTessellatorImpl.java
@@ -120,8 +120,7 @@ public class StationTessellatorImpl implements StationTessellator {
             LOGGER.info("Tessellator is nearing its maximum capacity. Increasing the buffer size from {} to {}", bufferSize, newBufferSize);
             access.stationapi$setBufferSize(newBufferSize);
             access.stationapi$setBuffer(Arrays.copyOf(access.stationapi$getBuffer(), newBufferSize));
-            // long arithmetic so the byte count can never overflow a signed int.
-            ByteBuffer newBuffer = GlAllocationUtils.allocateByteBuffer((int) ((long) newBufferSize * 4));
+            ByteBuffer newBuffer = GlAllocationUtils.allocateByteBuffer(newBufferSize * 4);
             access.stationapi$setByteBuffer(newBuffer);
             access.stationapi$setIntBuffer(newBuffer.asIntBuffer());
             access.stationapi$setFloatBuffer(newBuffer.asFloatBuffer());


### PR DESCRIPTION
Fix integer overflow in StationTessellatorImpl buffer growth

After a long play session, the Arsenic tessellator crashes while rendering GUI items I get an error closing the game

    java.lang.IllegalArgumentException: capacity < 0: (-2147483648)
        at java.base/java.nio.Buffer.createCapacityException
        at java.base/java.nio.ByteBuffer.allocateDirect
        ... GlAllocationUtils.allocateByteBuffer
        ... StationTessellatorImpl.ensureBufferCapacity

`StationTessellatorImpl.ensureBufferCapacity` grows the tessellator buffer by *doubling* `bufferSize` (an `int`) every time the buffer fills, and never shrinks it back. Vanilla `Tessellator.reset()` resets `vertexCount`/`bufferPosition` but does NOT reset `bufferSize`, so the doubled size accumulates across the whole session.

The buffer normally never grows, because vanilla `Tessellator.vertex()` auto-flushes (`draw()`) when it nears full. Arsenic's direct-write `quad()` path bypasses that auto-flush and instead calls `ensureBufferCapacity(48)`, which grows the buffer rather than flushing it. Over a long session the buffer therefore doubles repeatedly:

    base bufferSize = 2_097_152            (2^21)
    after 8 doublings: bufferSize = 536_870_912   (2^29)
    bufferSize * 4 (the byte-buffer allocation) = 2^31 -> overflows signed int = Integer.MIN_VALUE = -2147483648

`GlAllocationUtils.allocateByteBuffer(-2147483648)` then calls `ByteBuffer.allocateDirect(MIN_VALUE)`, which throws `capacity < 0`. (A latent ~2 GB `Arrays.copyOf(buffer, bufferSize)` allocation sits one line earlier as well.)

Fixed by capping `bufferSize` at a sane maximum, once the buffer is already at the ceiling, return without reallocating instead of doubling into an invalid capacity, and perform the byte-count arithmetic in `long` before the allocation, so even at the cap the computed capacity stays a correct positive `int`.
