### PR TITLE
Update buildscript

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -147,7 +147,6 @@ allprojects {
     // this fixes some edge cases with special characters not displaying correctly
     // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
     tasks.withType<JavaCompile> {
-        options.release = 17
         options.encoding = "UTF-8"
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,8 +5,8 @@ import net.modificationstation.stationapi.gradle.SubprojectHelpers.addDependency
 
 plugins {
     id("maven-publish")
-    id("fabric-loom") version "1.9-SNAPSHOT"
-    id("babric-loom-extension") version "1.9.2"
+    id("fabric-loom") version "1.16.2"
+    id("babric-loom-extension") version "1.16.1"
 }
 
 // https://stackoverflow.com/a/40101046 - Even with kotlin, gradle can't get it's shit together.
@@ -19,9 +19,13 @@ allprojects {
     apply(plugin = "fabric-loom")
     apply(plugin = "babric-loom-extension")
 
-    java.sourceCompatibility = JavaVersion.VERSION_17
-    java.targetCompatibility = JavaVersion.VERSION_17
-
+    java {
+        toolchain {
+            languageVersion.set(JavaLanguageVersion.of(17))
+        }
+        withSourcesJar()
+    }
+    
     repositories {
         maven(url = "https://maven.minecraftforge.net/")
         maven(url = "https://maven.glass-launcher.net/babric")
@@ -47,15 +51,13 @@ allprojects {
         }
     }
 
-    @Suppress("UnstableApiUsage")
     configurations {
-        create("transitiveImplementation")
-
-        // Required cause loom 0.14 for some reason doesn't remove asm-all 4.1. Ew.
-        all {
-            exclude(group = "org.ow2.asm", module = "asm-debug-all")
-            exclude(group = "org.ow2.asm", module = "asm-all")
-            exclude(group = "babric")
+        listOf("transitiveImplementation", "modImplementation").forEach { name ->
+            named(name) {
+                exclude(group = "org.ow2.asm", module = "asm-debug-all")
+                exclude(group = "org.ow2.asm", module = "asm-all")
+                exclude(group = "babric", module = "fabric-loader")
+            }
         }
     }
 
@@ -74,15 +76,15 @@ allprojects {
 
         modImplementation("net.fabricmc:fabric-loader:${project.properties["loader_version"]}")
 
-        "transitiveImplementation"(implementation("org.apache.commons:commons-lang3:3.12.0") as Dependency)
-        "transitiveImplementation"(implementation("commons-io:commons-io:2.11.0") as Dependency)
-        "transitiveImplementation"(implementation("net.jodah:typetools:${project.properties["typetools_version"]}") as Dependency)
-        "transitiveImplementation"(implementation("com.github.mineLdiver:UnsafeEvents:${project.properties["unsafeevents_version"]}") as Dependency)
-        "transitiveImplementation"(implementation("it.unimi.dsi:fastutil:${project.properties["fastutil_version"]}") as Dependency)
-        "transitiveImplementation"(implementation("com.github.ben-manes.caffeine:caffeine:${project.properties["caffeine_version"]}") as Dependency)
-        "transitiveImplementation"(implementation("com.mojang:datafixerupper:${project.properties["dfu_version"]}") as Dependency)
-        "transitiveImplementation"(implementation("maven.modrinth:spasm:${project.properties["spasm_version"]}") as Dependency)
-        "transitiveImplementation"(implementation("me.carleslc:Simple-Yaml:1.8.4") as Dependency)
+        transitiveImplementation(implementation("org.apache.commons:commons-lang3:3.12.0") as Dependency)
+        transitiveImplementation(implementation("commons-io:commons-io:2.11.0") as Dependency)
+        transitiveImplementation(implementation("net.jodah:typetools:${project.properties["typetools_version"]}") as Dependency)
+        transitiveImplementation(implementation("com.github.mineLdiver:UnsafeEvents:${project.properties["unsafeevents_version"]}") as Dependency)
+        transitiveImplementation(implementation("it.unimi.dsi:fastutil:${project.properties["fastutil_version"]}") as Dependency)
+        transitiveImplementation(implementation("com.github.ben-manes.caffeine:caffeine:${project.properties["caffeine_version"]}") as Dependency)
+        transitiveImplementation(implementation("com.mojang:datafixerupper:${project.properties["dfu_version"]}") as Dependency)
+        transitiveImplementation(implementation("maven.modrinth:spasm:${project.properties["spasm_version"]}") as Dependency)
+        transitiveImplementation(implementation("me.carleslc:Simple-Yaml:1.8.4") as Dependency)
 
         // not a runtime dependency unless we use something outside its events.
         modImplementation("net.glasslauncher.mods:GlassConfigAPI:${project.properties["gcapi_version"]}")
@@ -97,7 +99,7 @@ allprojects {
         // adds some useful annotations for miscellaneous uses. does not add any dependencies, though people without the lib will be missing some useful context hints.
         implementation("org.jetbrains:annotations:23.0.0")
 
-        modLocalRuntime("net.glasslauncher.mods:ModMenu:${project.properties["modmenu_version"]}")
+        modLocalRuntime("net.danygames2014:modmenu:${project.properties["modmenu_version"]}")
         modLocalRuntime("maven.modrinth:retrocommands:${project.properties["rc_version"]}") {
             isTransitive = false
         }
@@ -129,13 +131,6 @@ allprojects {
         }
     }
 
-    java {
-        // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-        // if it is present.
-        // If you remove this line, sources will not be generated.
-        withSourcesJar()
-    }
-
     // Include license inside of the mod jar
     configure<Jar>("jar") {
         from(rootProject.file("LICENSE")) {
@@ -147,6 +142,7 @@ allprojects {
     // this fixes some edge cases with special characters not displaying correctly
     // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
     tasks.withType<JavaCompile> {
+        options.release = 17
         options.encoding = "UTF-8"
     }
 
@@ -207,14 +203,15 @@ base.archivesName.set(project.properties["archives_base_name"] as String)
 version = (if (project.hasProperty("override_version")) (project.properties["override_version"] as String).substring(0, 7) else project.properties["mod_version"])!!
 
 subprojects {
+    version = rootProject.version
+    
     // This makes the older pre-releases easier to clean up.
     group = if (rootProject.hasProperty("override_version")) {
-        (project.properties["maven_group"] as String) + ".StationAPI.${(project.properties["override_version"] as String).substring(0, 7)}"
+        (rootProject.properties["maven_group"] as String) + ".StationAPI.${(rootProject.properties["override_version"] as String).substring(0, 7)}"
+    } else {
+        (rootProject.properties["maven_group"] as String) + ".StationAPI.submodule.$name"
     }
-    else {
-        (project.properties["maven_group"] as String) + ".StationAPI.submodule.${project.properties["archivesBaseName"]}"
-    }
-
+    
     configurations {
         create("out") {
             isCanBeConsumed = true
@@ -307,4 +304,9 @@ tasks.register<Jar>("testJar") {
 // Gradle I swear to fuck stop trying to do bullshit to the maven - calm
 tasks.withType<GenerateModuleMetadata> {
     enabled = false
+}
+
+// Gradle 9 fails the build if there are no tests, but we are using the test package for a test mod
+tasks.withType(Test::class.java) {
+    failOnNoDiscoveredTests = false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -315,6 +315,6 @@ tasks.withType<GenerateModuleMetadata> {
 }
 
 // Gradle 9 fails the build if there are no tests, but we are using the test package for a test mod
-tasks.withType(Test::class.java) {
+tasks.withType<Test> {
     failOnNoDiscoveredTests = false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,11 @@ allprojects {
         modLocalRuntime("maven.modrinth:retrocommands:${project.properties["rc_version"]}") {
             isTransitive = false
         }
+        
+        // The "enableAmiCompat" program argument needs to be present in order to apply a dev-only patch for AMI to work
+        modLocalRuntime("net.glasslauncher.mods:AlwaysMoreItems:${project.properties["ami_version"]}") {
+            isTransitive = false
+        }
 
         annotationProcessor("io.github.llamalad7:mixinextras-fabric:0.4.1")
 
@@ -291,6 +296,10 @@ loom {
         register("runTestmodServer") {
             source("test")
             server()
+        }
+
+        configureEach {
+            programArgs("enableAmiCompat")
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import net.modificationstation.stationapi.gradle.SubprojectHelpers.addDependency
 
 plugins {
     id("maven-publish")
-    id("fabric-loom") version "1.16.2"
+    id("fabric-loom") version "1.17.12"
     id("babric-loom-extension") version "1.16.1"
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ allprojects {
         }
         withSourcesJar()
     }
-    
+
     repositories {
         maven(url = "https://maven.minecraftforge.net/")
         maven(url = "https://maven.glass-launcher.net/babric")
@@ -103,7 +103,7 @@ allprojects {
         modLocalRuntime("maven.modrinth:retrocommands:${project.properties["rc_version"]}") {
             isTransitive = false
         }
-        
+
         // The "enableAmiCompat" program argument needs to be present in order to apply a dev-only patch for AMI to work
         modLocalRuntime("net.glasslauncher.mods:AlwaysMoreItems:${project.properties["ami_version"]}") {
             isTransitive = false
@@ -209,14 +209,14 @@ version = (if (project.hasProperty("override_version")) (project.properties["ove
 
 subprojects {
     version = rootProject.version
-    
+
     // This makes the older pre-releases easier to clean up.
     group = if (rootProject.hasProperty("override_version")) {
         (rootProject.properties["maven_group"] as String) + ".StationAPI.${(rootProject.properties["override_version"] as String).substring(0, 7)}"
     } else {
         (rootProject.properties["maven_group"] as String) + ".StationAPI.submodule.$name"
     }
-    
+
     configurations {
         create("out") {
             isCanBeConsumed = true

--- a/buildSrc/src/main/java/net/fabricmc/loom/util/GroovyXmlUtil.java
+++ b/buildSrc/src/main/java/net/fabricmc/loom/util/GroovyXmlUtil.java
@@ -25,7 +25,7 @@
 package net.fabricmc.loom.util;
 
 import groovy.util.Node;
-import groovy.xml.QName;
+import javax.xml.namespace.QName;
 
 public final class GroovyXmlUtil {
 	private GroovyXmlUtil() { }
@@ -46,7 +46,7 @@ public final class GroovyXmlUtil {
 		}
 
 		if (nodeName instanceof QName qName) {
-			return qName.matches(givenName);
+			return qName.getLocalPart().equals(givenName);
 		}
 
 		// New groovy 3 (gradle 7) class

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,3 +30,4 @@ fabric.loom.multiProjectOptimisation=true
     gcapi_version = 3.2.5
     modmenu_version = 1.1.1
     rc_version = 0.5.4
+    ami_version = 1.10.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ fabric.loom.multiProjectOptimisation=true
 # check these on https://fabricmc.net/use
     minecraft_version = b1.7.3
     yarn_mappings = b1.7.3+e1fe071
-    loader_version = 0.16.9
+    loader_version = 0.19.3
 
 # Library Properties
     typetools_version = 0.8.3
@@ -28,5 +28,5 @@ fabric.loom.multiProjectOptimisation=true
 
 # Test properties
     gcapi_version = 3.2.5
-    modmenu_version = 1.8.5-beta.11
+    modmenu_version = 1.1.1
     rc_version = 0.5.4

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/StationRecipesMixinPlugin.java
+++ b/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/StationRecipesMixinPlugin.java
@@ -13,7 +13,7 @@ import java.util.Set;
 public class StationRecipesMixinPlugin implements IMixinConfigPlugin {
     @Override
     public void onLoad(String mixinPackage) {
-        
+
     }
 
     @Override
@@ -33,30 +33,33 @@ public class StationRecipesMixinPlugin implements IMixinConfigPlugin {
 
     @Override
     public List<String> getMixins() {
-        if (FabricLoader.getInstance().isDevelopmentEnvironment() && FabricLoader.getInstance().isModLoaded("alwaysmoreitems")) {
-            boolean enableAmiCompat = false;
-
-            String[] launchArgs = FabricLoader.getInstance().getLaunchArguments(true);
-            for (String arg : launchArgs) {
-                if (arg.contains("enableAmiCompat")) {
-                    enableAmiCompat = true;
-                    break;
-                }
-            }
-
-            if (!enableAmiCompat) {
-                return null;
-            }
-            
-            StationAPI.LOGGER.info("AlwaysMoreItems detected in development environment, adding mixins to make it work");
-            
-            ArrayList<String> mixins = new ArrayList<>();
-            mixins.add("dev.StationShapedRecipeMixin");
-            mixins.add("dev.StationShapelessRecipeMixin");
-            return mixins;
+        if (!FabricLoader.getInstance().isDevelopmentEnvironment()) {
+            return null;
         }
-        
-        return null;
+
+        if (FabricLoader.getInstance().isModLoaded("alwaysmoreitems")) {
+            return null;
+        }
+
+        boolean enableAmiCompat = false;
+        String[] launchArgs = FabricLoader.getInstance().getLaunchArguments(true);
+        for (String arg : launchArgs) {
+            if (arg.contains("enableAmiCompat")) {
+                enableAmiCompat = true;
+                break;
+            }
+        }
+
+        if (!enableAmiCompat) {
+            return null;
+        }
+
+        StationAPI.LOGGER.info("AlwaysMoreItems detected in development environment, adding mixins to make it work");
+
+        ArrayList<String> mixins = new ArrayList<>();
+        mixins.add("dev.StationShapedRecipeMixin");
+        mixins.add("dev.StationShapelessRecipeMixin");
+        return mixins;
     }
 
     @Override

--- a/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/StationRecipesMixinPlugin.java
+++ b/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/StationRecipesMixinPlugin.java
@@ -1,0 +1,71 @@
+package net.modificationstation.stationapi.mixin;
+
+import net.fabricmc.loader.api.FabricLoader;
+import net.modificationstation.stationapi.api.StationAPI;
+import org.objectweb.asm.tree.ClassNode;
+import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
+import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class StationRecipesMixinPlugin implements IMixinConfigPlugin {
+    @Override
+    public void onLoad(String mixinPackage) {
+        
+    }
+
+    @Override
+    public String getRefMapperConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean shouldApplyMixin(String targetClassName, String mixinClassName) {
+        return true;
+    }
+
+    @Override
+    public void acceptTargets(Set<String> myTargets, Set<String> otherTargets) {
+
+    }
+
+    @Override
+    public List<String> getMixins() {
+        if (FabricLoader.getInstance().isDevelopmentEnvironment() && FabricLoader.getInstance().isModLoaded("alwaysmoreitems")) {
+            boolean enableAmiCompat = false;
+
+            String[] launchArgs = FabricLoader.getInstance().getLaunchArguments(true);
+            for (String arg : launchArgs) {
+                if (arg.contains("enableAmiCompat")) {
+                    enableAmiCompat = true;
+                    break;
+                }
+            }
+
+            if (!enableAmiCompat) {
+                return null;
+            }
+            
+            StationAPI.LOGGER.info("AlwaysMoreItems detected in development environment, adding mixins to make it work");
+            
+            ArrayList<String> mixins = new ArrayList<>();
+            mixins.add("dev.StationShapedRecipeMixin");
+            mixins.add("dev.StationShapelessRecipeMixin");
+            return mixins;
+        }
+        
+        return null;
+    }
+
+    @Override
+    public void preApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+
+    @Override
+    public void postApply(String targetClassName, ClassNode targetClass, String mixinClassName, IMixinInfo mixinInfo) {
+
+    }
+}

--- a/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/recipe/dev/StationShapedRecipeMixin.java
+++ b/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/recipe/dev/StationShapedRecipeMixin.java
@@ -1,0 +1,19 @@
+package net.modificationstation.stationapi.mixin.recipe.dev;
+
+import net.minecraft.item.ItemStack;
+import net.modificationstation.stationapi.impl.recipe.StationShapedRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+@SuppressWarnings("UnusedMixin") // Added in a mixin plugin only in development environment with AlwaysMoreItems present
+@Mixin(StationShapedRecipe.class)
+public abstract class StationShapedRecipeMixin {
+    @Shadow
+    public abstract ItemStack getOutput();
+
+    @Unique
+    public ItemStack method_2073() {
+        return this.getOutput();
+    }
+}

--- a/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/recipe/dev/StationShapelessRecipeMixin.java
+++ b/station-recipes-v0/src/main/java/net/modificationstation/stationapi/mixin/recipe/dev/StationShapelessRecipeMixin.java
@@ -1,0 +1,19 @@
+package net.modificationstation.stationapi.mixin.recipe.dev;
+
+import net.minecraft.item.ItemStack;
+import net.modificationstation.stationapi.impl.recipe.StationShapelessRecipe;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+
+@SuppressWarnings("UnusedMixin") // Added in a mixin plugin only in development environment with AlwaysMoreItems present
+@Mixin(StationShapelessRecipe.class)
+public abstract class StationShapelessRecipeMixin {
+    @Shadow
+    public abstract ItemStack getOutput();
+
+    @Unique
+    public ItemStack method_2073() {
+        return this.getOutput();
+    }
+}

--- a/station-recipes-v0/src/main/resources/station-recipes-v0.mixins.json
+++ b/station-recipes-v0/src/main/resources/station-recipes-v0.mixins.json
@@ -3,6 +3,7 @@
   "minVersion": "0.8",
   "package": "net.modificationstation.stationapi.mixin.recipe",
   "compatibilityLevel": "JAVA_17",
+  "plugin": "net.modificationstation.stationapi.mixin.StationRecipesMixinPlugin",
   "mixins": [
     "CraftingRecipeManagerMixin",
     "CraftingResultMixin",


### PR DESCRIPTION
Updates the StationAPI buildscript to latest Loom, Boom and Fabric Loader

I have tested that StationAPI (with and without test mod) runs, builds and produces the correct maven artifacts

# AMI
Regarding AMI, because of a bug in Loom where it fails to properly remap references to methods from a vanilla interface implemented in a StationAPI class, I have chosen to add a mixin which adds these methods with their intermediary names as to not modify the source itself and to not cause a conflict when remapping to production. These will only get applied if the following conditions are met:
* Is Development Environmnet
* Always More Items is loaded
* The `enableAmiCompat` program argument is entered

The program argument is automatically added by the stapi buildscript in the loom section. The program argument exists to not trigger this mixin in development environments depending on StationAPI.