### PR TITLE
Override getBiome(ChunkPos chunkPos) in NetherBiomeSourceImpl 

### DIFF
--- a/station-worldgen-api-v0/src/main/java/net/modificationstation/stationapi/impl/worldgen/NetherBiomeSourceImpl.java
+++ b/station-worldgen-api-v0/src/main/java/net/modificationstation/stationapi/impl/worldgen/NetherBiomeSourceImpl.java
@@ -1,5 +1,6 @@
 package net.modificationstation.stationapi.impl.worldgen;
 
+import net.minecraft.util.math.ChunkPos;
 import net.minecraft.world.biome.Biome;
 import net.minecraft.world.biome.source.FixedBiomeSource;
 import net.modificationstation.stationapi.api.worldgen.BiomeAPI;
@@ -12,7 +13,12 @@ public class NetherBiomeSourceImpl extends FixedBiomeSource {
     private NetherBiomeSourceImpl() {
         super(Biome.HELL, 1.0, 0.0);
     }
-    
+
+    @Override
+    public Biome getBiome(ChunkPos chunkPos) {
+        return getBiome(chunkPos.x << 4, chunkPos.z << 4);
+    }
+
     @Override
     public Biome getBiome(int x, int z) {
         return getBiomesInArea(BUFFER, x, z, 1, 1)[0];


### PR DESCRIPTION
While working on my own mod I found that while in the nether, getBiome(ChunkPos chunkPos) always returns Biome.HELL.
As it turns out, the method being accessed was instead the one from the base FixedBiomeProvider which is not used anywhere else, and thus would always return the vanilla Biome.HELL instead of getting it from the proper provider.
After a quick test this change seems to have resolved the issue.

Fixes #265 