### PR TITLE
Remove Deprecated From ItemWithRenderer and Actually Implement

### DIFF
--- a/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/model/item/ItemWithRenderer.java
+++ b/station-renderer-api-v0/src/main/java/net/modificationstation/stationapi/api/client/model/item/ItemWithRenderer.java
@@ -4,15 +4,23 @@ import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.texture.TextureManager;
 import net.minecraft.item.ItemStack;
+import org.lwjgl.opengl.GL11;
 
-@Deprecated
 public interface ItemWithRenderer {
 
-    @Deprecated
     void renderItemOnGui(ItemRenderer itemRenderer, TextRenderer textRenderer, TextureManager textureManager, int itemId, int damage, int textureIndex, int x, int y);
 
-    @Deprecated
     default void renderItemOnGui(ItemRenderer itemRenderer, TextRenderer textRenderer, TextureManager textureManager, ItemStack stack, int x, int y) {
         renderItemOnGui(itemRenderer, textRenderer, textureManager, stack.itemId, stack.getDamage(), stack.getTextureId(), x, y);
+    }
+
+    default void renderItemInWorld(ItemRenderer itemRenderer, TextRenderer textRenderer, TextureManager textureManager, ItemStack stack, float brightness) {
+        GL11.glColor3f(brightness, brightness, brightness);
+        renderItemOnGui(itemRenderer, textRenderer, textureManager, stack, 0, 0);
+    }
+
+    default void renderItemInHand(ItemRenderer itemRenderer, TextRenderer textRenderer, TextureManager textureManager, ItemStack stack, float brightness) {
+        GL11.glColor3f(brightness, brightness, brightness);
+        renderItemOnGui(itemRenderer, textRenderer, textureManager, stack, 0, 0);
     }
 }

--- a/station-renderer-arsenic/src/main/java/net/modificationstation/stationapi/impl/client/arsenic/renderer/render/ArsenicItemRenderer.java
+++ b/station-renderer-arsenic/src/main/java/net/modificationstation/stationapi/impl/client/arsenic/renderer/render/ArsenicItemRenderer.java
@@ -1,7 +1,9 @@
 package net.modificationstation.stationapi.impl.client.arsenic.renderer.render;
 
 import lombok.val;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.block.BlockRenderManager;
@@ -85,7 +87,14 @@ public final class ArsenicItemRenderer {
                     glTranslatef(var30, var31, var32);
                 }
 
-                itemRendererAccessor.getBlockRenderer().render(block, var10.getDamage(), item.getBrightnessAtEyes(delta));
+                if (item.stack.getItem() instanceof ItemWithRenderer renderer) {
+                    //noinspection deprecation
+                    Minecraft minecraft = (Minecraft) FabricLoader.getInstance().getGameInstance();
+                    renderer.renderItemInWorld(itemRenderer, minecraft.textRenderer, minecraft.textureManager, item.stack, item.getBrightnessAtEyes(delta));
+                }
+                else {
+                    itemRendererAccessor.getBlockRenderer().render(block, var10.getDamage(), item.getBrightnessAtEyes(delta));
+                }
                 glPopMatrix();
             }
         } else {

--- a/station-renderer-arsenic/src/main/java/net/modificationstation/stationapi/impl/client/arsenic/renderer/render/ArsenicOverlayRenderer.java
+++ b/station-renderer-arsenic/src/main/java/net/modificationstation/stationapi/impl/client/arsenic/renderer/render/ArsenicOverlayRenderer.java
@@ -301,7 +301,7 @@ public final class ArsenicOverlayRenderer {
             renderer.renderItemInHand(itemRenderer, minecraft.textRenderer, minecraft.textureManager, var5, var3.getBrightnessAtEyes(f));
         }
         else {
-        this.renderItem3D(var3, var5);
+            this.renderItem3D(var3, var5);
         }
         glPopMatrix();
     }

--- a/station-renderer-arsenic/src/main/java/net/modificationstation/stationapi/impl/client/arsenic/renderer/render/ArsenicOverlayRenderer.java
+++ b/station-renderer-arsenic/src/main/java/net/modificationstation/stationapi/impl/client/arsenic/renderer/render/ArsenicOverlayRenderer.java
@@ -1,13 +1,17 @@
 package net.modificationstation.stationapi.impl.client.arsenic.renderer.render;
 
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.Block;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.render.Tessellator;
 import net.minecraft.client.render.block.BlockRenderManager;
 import net.minecraft.client.render.entity.EntityRenderDispatcher;
 import net.minecraft.client.render.entity.EntityRenderer;
 import net.minecraft.client.render.entity.PlayerEntityRenderer;
 import net.minecraft.client.render.item.HeldItemRenderer;
+import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.platform.Lighting;
+import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.ClientPlayerEntity;
 import net.minecraft.item.Item;
@@ -15,6 +19,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.map.MapState;
 import net.minecraft.util.math.MathHelper;
 import net.modificationstation.stationapi.api.client.StationRenderAPI;
+import net.modificationstation.stationapi.api.client.model.item.ItemWithRenderer;
 import net.modificationstation.stationapi.api.client.render.model.BakedModel;
 import net.modificationstation.stationapi.api.client.render.model.VanillaBakedModel;
 import net.modificationstation.stationapi.api.client.render.model.json.ModelTransformation;
@@ -50,8 +55,17 @@ public final class ArsenicOverlayRenderer {
 
     private void renderVanilla(LivingEntity entity, ItemStack item, SpriteAtlasTexture atlas) {
         Block block;
-        if (item.getItem() instanceof BlockItemForm blockItemForm && BlockRenderManager.isSideLit((block = blockItemForm.getBlock()).getRenderType()))
-            access.stationapi$getBlockRenderManager().render(block, item.getDamage(), entity.getBrightnessAtEyes(1.0F));
+        if (item.getItem() instanceof BlockItemForm blockItemForm && BlockRenderManager.isSideLit((block = blockItemForm.getBlock()).getRenderType())) {
+            if (item.getItem() instanceof ItemWithRenderer renderer) {
+                //noinspection deprecation
+                Minecraft minecraft = (Minecraft) FabricLoader.getInstance().getGameInstance();
+                ItemRenderer itemRenderer = (ItemRenderer) EntityRenderDispatcher.INSTANCE.get(ItemEntity.class);
+                renderer.renderItemInHand(itemRenderer, minecraft.textRenderer, minecraft.textureManager, item, entity.getBrightnessAtEyes(1f));
+            }
+            else {
+                access.stationapi$getBlockRenderManager().render(block, item.getDamage(), entity.getBrightnessAtEyes(1.0F));
+            }
+        }
         else {
             Tessellator var3 = Tessellator.INSTANCE;
             int var4 = entity.getItemStackTextureId(item);
@@ -280,7 +294,15 @@ public final class ArsenicOverlayRenderer {
         f4 = 0.4f;
         glScalef(f4, f4, f4);
         if (var5.getItem().isHandheldRod()) glRotatef(180.0f, 0.0f, 1.0f, 0.0f);
+        if (var5.getItem() instanceof ItemWithRenderer renderer) {
+            //noinspection deprecation
+            Minecraft minecraft = (Minecraft) FabricLoader.getInstance().getGameInstance();
+            ItemRenderer itemRenderer = (ItemRenderer) EntityRenderDispatcher.INSTANCE.get(ItemEntity.class);
+            renderer.renderItemInHand(itemRenderer, minecraft.textRenderer, minecraft.textureManager, var5, var3.getBrightnessAtEyes(f));
+        }
+        else {
         this.renderItem3D(var3, var5);
+        }
         glPopMatrix();
     }
 


### PR DESCRIPTION
Mine, this interface is so half baked I'm *astonished* if anyone actually ever used this.

Also don't deprecate shit we don't have a replacement for kthanksbye.

Here it is with some half baked assumptions made to not break backwards compat. You're welcome.

<details>
<summary>Details</summary>

MFW mine does something inexplicable and gives and even more inexplicable reason
![](https://en.meming.world/images/en/5/5e/Bald_Guy_Staring.jpg)

</details>