### PR TITLE
fix: Deep copy Station NBT in PlayerInventory#combineStacks (#270)

### DIFF
--- a/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/PlayerInventoryMixin.java
+++ b/station-items-v0/src/main/java/net/modificationstation/stationapi/mixin/item/PlayerInventoryMixin.java
@@ -32,7 +32,7 @@ class PlayerInventoryMixin {
             @Local(index = 1, argsOnly = true) ItemStack stack
     ) {
         final var newStack = original.call(id, count, damage);
-        StationNBTSetter.cast(newStack).setStationNbt(stack.getStationNbt());
+        StationNBTSetter.cast(newStack).setStationNbt(stack.getStationNbt().copy());
         return newStack;
     }
 


### PR DESCRIPTION
## Summary

Fixes #270

`PlayerInventoryMixin.stationapi_newItemStack` was injecting into `PlayerInventory.combineStacks` to propagate Station NBT onto the newly created `ItemStack`. However, it was passing a **direct reference** to the source stack's `NbtCompound` instead of a deep copy:

```java
// Before (bug)
StationNBTSetter.cast(newStack).setStationNbt(stack.getStationNbt());

// After (fix)
StationNBTSetter.cast(newStack).setStationNbt(stack.getStationNbt().copy());
```

## Root Cause

Both the original and combined stacks were sharing the same `NbtCompound` object in memory. Mutating the NBT of one stack would silently corrupt the other — a classic object aliasing bug.

## Verification

- Confirmed all other NBT propagation paths already call `.copy()`:
  - `ItemStackMixin.stationapi_copy` 
  - `ItemStackMixin.stationapi_setSplitStackNbt` 
  - This was the only missing `.copy()` call in the codebase.
- Build Status: Compiled and tested successfully locally via `./gradlew build` 