### PR TITLE
Metadata-dependent rules for the block datafixer

### DIFF
--- a/src/test/java/net/modificationstation/sltest/datafixer/DataFixerListener.java
+++ b/src/test/java/net/modificationstation/sltest/datafixer/DataFixerListener.java
@@ -8,8 +8,7 @@ import net.modificationstation.stationapi.api.util.Util;
 
 import java.lang.invoke.MethodHandles;
 
-import static net.modificationstation.stationapi.api.vanillafix.datafixer.schema.StationFlatteningItemStackSchema.putItem;
-import static net.modificationstation.stationapi.api.vanillafix.datafixer.schema.StationFlatteningItemStackSchema.putState;
+import static net.modificationstation.stationapi.api.vanillafix.datafixer.schema.StationFlatteningItemStackSchema.*;
 
 public class DataFixerListener {
     static {
@@ -23,6 +22,7 @@ public class DataFixerListener {
         putState(99, "sltest:farlands_block", Util.make(new NbtCompound(), tag -> tag.putString("facing", "north")));
         putState(100, "sltest:freezer");
         putState(101, "sltest:altar");
+        putStateMetaRule(17, 2, "minecraft:wool");
         putItem(360, "sltest:test_item");
         putItem(361, "sltest:test_pickaxe");
         putItem(362, "sltest:nbt_item");

--- a/src/test/java/net/modificationstation/sltest/datafixer/DataFixerListener.java
+++ b/src/test/java/net/modificationstation/sltest/datafixer/DataFixerListener.java
@@ -22,7 +22,7 @@ public class DataFixerListener {
         putState(99, "sltest:farlands_block", Util.make(new NbtCompound(), tag -> tag.putString("facing", "north")));
         putState(100, "sltest:freezer");
         putState(101, "sltest:altar");
-        putStateMetaRule(17, 2, "minecraft:wool");
+        putStateMetaRule(17, 2, 10, "minecraft:wool");
         putItem(360, "sltest:test_item");
         putItem(361, "sltest:test_pickaxe");
         putItem(362, "sltest:nbt_item");

--- a/src/test/java/net/modificationstation/sltest/datafixer/DataFixerListener.java
+++ b/src/test/java/net/modificationstation/sltest/datafixer/DataFixerListener.java
@@ -22,7 +22,7 @@ public class DataFixerListener {
         putState(99, "sltest:farlands_block", Util.make(new NbtCompound(), tag -> tag.putString("facing", "north")));
         putState(100, "sltest:freezer");
         putState(101, "sltest:altar");
-        putStateMetaRule(17, 2, 10, "minecraft:wool");
+        putStateMetaRule(17, 2, "minecraft:wool", 10);
         putItem(360, "sltest:test_item");
         putItem(361, "sltest:test_pickaxe");
         putItem(362, "sltest:nbt_item");

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datadamager/damage/StationFlatteningToMcRegionChunkDamage.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datadamager/damage/StationFlatteningToMcRegionChunkDamage.java
@@ -23,6 +23,9 @@ import java.util.function.Function;
 
 import static net.modificationstation.stationapi.impl.world.FlattenedWorldManager.SECTIONS;
 
+/**
+ * Reverses Station API's block conversion into identifiers and reverts blocks into numeric IDs
+ */
 public class StationFlatteningToMcRegionChunkDamage extends DataFix {
     private final static int CHUNK_SIZE = 16 * 128 * 16;
     private final static byte[] DEFAULT_BLOCK_LIGHT = new byte[CHUNK_SIZE >> 1];

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
@@ -98,6 +98,7 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
                     // Preparation for conversion. References are maintained for faster key comparison
                     // See "transform" method at the bottom of this file for actual conversion
                     section.setBlock(x, y, z, StationFlatteningItemStackSchema.lookupState(block, metadata));
+                    // Replace old metadata with new one if specified
                     int newMetadata = StationFlatteningItemStackSchema.lookupMetadata(block, metadata);
                     if (newMetadata == MetaDependentIdConversion.UNSPECIFIED_META) {
                         newMetadata = metadata;

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
@@ -96,7 +96,7 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
                     Section section = sections[sectionY];
                     // Preparation for conversion. References are maintained for faster key comparison
                     // See "transform" method at the bottom of this file for actual conversion
-                    section.setBlock(x, y, z, StationFlatteningItemStackSchema.lookupState(block));
+                    section.setBlock(x, y, z, StationFlatteningItemStackSchema.lookupState(block, metadata));
                     section.setMetadata(x, y, z, metadata);
                 }
             }
@@ -162,7 +162,7 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
         public Section(Dynamic<?> section) {
             this.section = section;
             y = section.get("y").asInt(0);
-            Dynamic<?> air = StationFlatteningItemStackSchema.lookupState(0); // same applies
+            Dynamic<?> air = StationFlatteningItemStackSchema.lookupState(0, 0); // same applies
             seenStates.add(air);
             paletteData.add(air);
             paletteMap.add(air);

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
@@ -24,6 +24,11 @@ import java.util.Optional;
 
 import static net.modificationstation.stationapi.impl.world.FlattenedWorldManager.SECTIONS;
 
+/**
+ * Datafixer used for converting McRegion worlds (Vanilla Beta 1.7.3 world format)
+ * <p>
+ * Handles block conversions
+ */
 public class McRegionToStationFlatteningChunkFix extends DataFix {
     private final String name;
 
@@ -75,7 +80,7 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
         public Dynamic<?> transform() {
             Dynamic<?> self = this.level;
 
-            // create sections with blocks
+            // Create sections with blocks
             Section[] sections = new Section[8];
             for (int i = 0; i < 32768; i++) {
                 int worldY = i & 0b1111111;
@@ -84,17 +89,19 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
                 int z = i >> 7 & 0b1111;
                 int x = i >> 11;
                 int block = Byte.toUnsignedInt(blocks.get(i));
-                int data = this.data.get(x, worldY, z);
-                if (block > 0 || data > 0) {
+                int metadata = this.data.get(x, worldY, z);
+                if (block > 0 || metadata > 0) {
                     if (sections[sectionY] == null)
                         sections[sectionY] = new Section(self.createMap(Map.of(self.createString("y"), self.createByte((byte) sectionY))));
                     Section section = sections[sectionY];
-                    section.setBlock(x, y, z, StationFlatteningItemStackSchema.lookupState(block)); // do not convert just yet. we need same references for faster key comparison
-                    section.setData(x, y, z, data);
+                    // Preparation for conversion. References are maintained for faster key comparison
+                    // See "transform" method at the bottom of this file for actual conversion
+                    section.setBlock(x, y, z, StationFlatteningItemStackSchema.lookupState(block));
+                    section.setMetadata(x, y, z, metadata);
                 }
             }
 
-            // add lighting in created sections
+            // Add lighting in created sections
             for (Section section : sections) {
                 if (section != null) {
                     int sectionY = section.y;
@@ -110,13 +117,13 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
                 }
             }
 
-            // expand height map
-            byte[] height_map = new byte[512];
-            for (int i = 0; i < height_map.length >> 1; i++) height_map[i << 1] = this.height_map.get(i);
+            // Expand height map
+            byte[] heightMap = new byte[512];
+            for (int i = 0; i < heightMap.length >> 1; i++) heightMap[i << 1] = this.height_map.get(i);
 
             return self
                     .set(SECTIONS, self.createList(Arrays.stream(sections).filter(Objects::nonNull).map(Section::transform)))
-                    .set("height_map", self.createByteList(ByteBuffer.wrap(height_map)))
+                    .set("height_map", self.createByteList(ByteBuffer.wrap(heightMap)))
                     .remove("BlockLight")
                     .remove("Blocks")
                     .remove("Data")
@@ -170,7 +177,7 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
             states[(y << 4 | z) << 4 | x] = addTo(paletteMap, state);
         }
 
-        public void setData(int x, int y, int z, int data) {
+        public void setMetadata(int x, int y, int z, int data) {
             this.data.setValue(x << 8 | y << 4 | z, data);
         }
 
@@ -180,7 +187,8 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
 
         public Dynamic<?> transform() {
             Dynamic<?> self = this.section;
-            Dynamic<?> palette = self.createList(paletteData.stream().map(dynamic -> dynamic.convert(self.getOps()))); // instead, convert when used
+            // Convert previously prepared values
+            Dynamic<?> palette = self.createList(paletteData.stream().map(dynamic -> dynamic.convert(self.getOps())));
             PackedIntegerArray array = new PackedIntegerArray(Math.max(4, MathHelper.ceilLog2(paletteData.size())), states.length);
             for (int i = 0; i < states.length; i++) array.set(i, states[i]);
             Dynamic<?> data = self.createLongList(Arrays.stream(array.getData()));

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/fix/McRegionToStationFlatteningChunkFix.java
@@ -15,6 +15,7 @@ import net.modificationstation.stationapi.api.util.collection.Int2ObjectBiMap;
 import net.modificationstation.stationapi.api.util.collection.PackedIntegerArray;
 import net.modificationstation.stationapi.api.util.math.MathHelper;
 import net.modificationstation.stationapi.api.vanillafix.datafixer.schema.StationFlatteningItemStackSchema;
+import net.modificationstation.stationapi.api.vanillafix.util.MetaDependentIdConversion;
 
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -97,7 +98,11 @@ public class McRegionToStationFlatteningChunkFix extends DataFix {
                     // Preparation for conversion. References are maintained for faster key comparison
                     // See "transform" method at the bottom of this file for actual conversion
                     section.setBlock(x, y, z, StationFlatteningItemStackSchema.lookupState(block, metadata));
-                    section.setMetadata(x, y, z, metadata);
+                    int newMetadata = StationFlatteningItemStackSchema.lookupMetadata(block, metadata);
+                    if (newMetadata == MetaDependentIdConversion.UNSPECIFIED_META) {
+                        newMetadata = metadata;
+                    }
+                    section.setMetadata(x, y, z, newMetadata);
                 }
             }
 

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/McRegionSchemaB1_7_3.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/McRegionSchemaB1_7_3.java
@@ -9,6 +9,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 
+/**
+ *
+ */
 public class McRegionSchemaB1_7_3 extends Schema {
     public McRegionSchemaB1_7_3(int versionKey, Schema parent) {
         super(versionKey, parent);

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/McRegionSchemaB1_7_3.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/McRegionSchemaB1_7_3.java
@@ -10,7 +10,9 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 /**
- *
+ * Defines conversion rules for different parts of the chunk data
+ * <p>
+ * Includes registries for Vanilla entities and block entities
  */
 public class McRegionSchemaB1_7_3 extends Schema {
     public McRegionSchemaB1_7_3(int versionKey, Schema parent) {

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -39,13 +39,27 @@ public class StationFlatteningItemStackSchema extends Schema {
 
     /**
      * Assigns a numeric block ID to an NBT compound with the new identifier and block state rules
+     * <p>
+     * Reassigning an ID keeps any metadata rules already added for it, as each rule carries its own tag
      * @param oldId Numeric block ID to be converted
      * @param tag Tag with the identifier and block state rules
+     * @throws IllegalArgumentException if oldId is out of range
      */
     public static void putState(int oldId, NbtCompound tag) {
+        if (oldId < 0 || oldId >= OLD_ID_TO_BLOCKSTATE.length) {
+            throw new IllegalArgumentException(
+                    "Block ID " + oldId + " is out of range, it must be between 0 and " +
+                    (OLD_ID_TO_BLOCKSTATE.length - 1)
+            );
+        }
         String id = tag.getString("Name");
         BLOCK_TO_OLD_ID.put(id, oldId);
-        OLD_ID_TO_BLOCKSTATE[oldId] = new MetaDependentIdConversion(tag);
+        MetaDependentIdConversion rule = OLD_ID_TO_BLOCKSTATE[oldId];
+        if (rule == null) {
+            OLD_ID_TO_BLOCKSTATE[oldId] = new MetaDependentIdConversion(tag);
+        } else {
+            rule.setDefaultTag(tag);
+        }
         putItem(oldId, id);
     }
 

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -49,16 +49,16 @@ public class StationFlatteningItemStackSchema extends Schema {
         putItem(oldId, id);
     }
 
-    public static void putStateMetaRule(int oldId, int meta, String id) {
-        putStateMetaRule(oldId, meta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)));
+    public static void putStateMetaRule(int oldId, int meta, int outputMeta, String id) {
+        putStateMetaRule(oldId, meta, outputMeta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)));
     }
 
-    public static void putStateMetaRule(int oldId, int meta, NbtCompound tag) {
+    public static void putStateMetaRule(int oldId, int meta, int outputMeta, NbtCompound tag) {
         MetaDependentIdConversion rule;
         if (oldId >= 0 && oldId < OLD_ID_TO_BLOCKSTATE.length) {
             rule = OLD_ID_TO_BLOCKSTATE[oldId];
             if (rule != null) {
-                rule.addMetaDependentTag(meta, tag);
+                rule.addMetaDependentTag(meta, tag, outputMeta);
                 OLD_ID_TO_BLOCKSTATE[oldId] = rule;
             }
         }
@@ -76,6 +76,14 @@ public class StationFlatteningItemStackSchema extends Schema {
             rule = OLD_ID_TO_BLOCKSTATE[stateId];
         }
         return rule == null ? OLD_ID_TO_BLOCKSTATE[0].getDefaultTag() : rule.getTagForMeta(metadata);
+    }
+
+    public static int lookupMetadata(int stateId, int metadata) {
+        MetaDependentIdConversion rule = null;
+        if (stateId >= 0 && stateId < OLD_ID_TO_BLOCKSTATE.length) {
+            rule = OLD_ID_TO_BLOCKSTATE[stateId];
+        }
+        return rule == null ? MetaDependentIdConversion.UNSPECIFIED_META : rule.getOutputMeta(metadata);
     }
 
     /**

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -57,7 +57,8 @@ public class StationFlatteningItemStackSchema extends Schema {
      * @param meta Old metadata
      * @param id New identifier (including the namespace)
      * @param outputMeta New metadata, or {@link MetaDependentIdConversion#UNSPECIFIED_META} to keep the old one
-     * @throws IllegalArgumentException if outputMeta is out of range
+     * @throws IllegalArgumentException if oldId has no state mapping,
+     *                                  or if oldId, meta or outputMeta is out of range
      */
     public static void putStateMetaRule(int oldId, int meta, String id, int outputMeta) {
         putStateMetaRule(oldId, meta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)), outputMeta);
@@ -71,17 +72,23 @@ public class StationFlatteningItemStackSchema extends Schema {
      * @param meta Old metadata
      * @param tag Tag with the identifier and block state rules
      * @param outputMeta New metadata, or {@link MetaDependentIdConversion#UNSPECIFIED_META} to keep the old one
-     * @throws IllegalArgumentException if outputMeta is out of range
+     * @throws IllegalArgumentException if oldId has no state mapping,
+     *                                  or if oldId, meta or outputMeta is out of range
      */
     public static void putStateMetaRule(int oldId, int meta, NbtCompound tag, int outputMeta) {
-        MetaDependentIdConversion rule;
-        if (oldId >= 0 && oldId < OLD_ID_TO_BLOCKSTATE.length) {
-            rule = OLD_ID_TO_BLOCKSTATE[oldId];
-            if (rule != null) {
-                rule.addMetaDependentTag(meta, tag, outputMeta);
-                OLD_ID_TO_BLOCKSTATE[oldId] = rule;
-            }
+        if (oldId < 0 || oldId >= OLD_ID_TO_BLOCKSTATE.length) {
+            throw new IllegalArgumentException(
+                    "Block ID " + oldId + " is out of range, it must be between 0 and " +
+                    (OLD_ID_TO_BLOCKSTATE.length - 1)
+            );
         }
+        MetaDependentIdConversion rule = OLD_ID_TO_BLOCKSTATE[oldId];
+        if (rule == null) {
+            throw new IllegalArgumentException(
+                    "Block ID " + oldId + " has no state mapping, call putState for it before adding metadata rules"
+            );
+        }
+        rule.addMetaDependentTag(meta, tag, outputMeta);
     }
 
     /**

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -55,11 +55,11 @@ public class StationFlatteningItemStackSchema extends Schema {
      * <em>Must be used after the putState method<em/>
      * @param oldId Numeric block ID to add the rule to
      * @param meta Old metadata
-     * @param outputMeta New metadata
      * @param id New identifier (including the namespace)
+     * @param outputMeta New metadata
      */
-    public static void putStateMetaRule(int oldId, int meta, int outputMeta, String id) {
-        putStateMetaRule(oldId, meta, outputMeta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)));
+    public static void putStateMetaRule(int oldId, int meta, String id, int outputMeta) {
+        putStateMetaRule(oldId, meta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)), outputMeta);
     }
 
     /**
@@ -68,10 +68,10 @@ public class StationFlatteningItemStackSchema extends Schema {
      * <em>Must be used after the putState method<em/>
      * @param oldId Numeric block ID to add the rule to
      * @param meta Old metadata
-     * @param outputMeta New metadata
      * @param tag Tag with the identifier and block state rules
+     * @param outputMeta New metadata
      */
-    public static void putStateMetaRule(int oldId, int meta, int outputMeta, NbtCompound tag) {
+    public static void putStateMetaRule(int oldId, int meta, NbtCompound tag, int outputMeta) {
         MetaDependentIdConversion rule;
         if (oldId >= 0 && oldId < OLD_ID_TO_BLOCKSTATE.length) {
             rule = OLD_ID_TO_BLOCKSTATE[oldId];

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -28,10 +28,20 @@ public class StationFlatteningItemStackSchema extends Schema {
         }));
     }
 
+    /**
+     * Assigns a numeric block ID to its new identifier
+     * @param oldId Numeric block ID to be converted
+     * @param id New identifier (including the namespace)
+     */
     public static void putState(int oldId, String id) {
         putState(oldId, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)));
     }
 
+    /**
+     * Assigns a numeric block ID to an NBT compound with the new identifier and block state rules
+     * @param oldId Numeric block ID to be converted
+     * @param tag Tag with the identifier and block state rules
+     */
     public static void putState(int oldId, NbtCompound tag) {
         String id = tag.getString("Name");
         BLOCK_TO_OLD_ID.put(id, oldId);
@@ -40,6 +50,11 @@ public class StationFlatteningItemStackSchema extends Schema {
         putItem(oldId, id);
     }
 
+    /**
+     * Takes a numeric block ID and returns a block entry for the datafixer
+     * @param stateId Numeric ID of the block
+     * @return Dynamic which contains the new ID
+     */
     public static Dynamic<?> lookupState(int stateId) {
         Dynamic<?> dynamic = null;
         if (stateId >= 0 && stateId < OLD_ID_TO_BLOCKSTATE.length) {

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -56,7 +56,8 @@ public class StationFlatteningItemStackSchema extends Schema {
      * @param oldId Numeric block ID to add the rule to
      * @param meta Old metadata
      * @param id New identifier (including the namespace)
-     * @param outputMeta New metadata
+     * @param outputMeta New metadata, or {@link MetaDependentIdConversion#UNSPECIFIED_META} to keep the old one
+     * @throws IllegalArgumentException if outputMeta is out of range
      */
     public static void putStateMetaRule(int oldId, int meta, String id, int outputMeta) {
         putStateMetaRule(oldId, meta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)), outputMeta);
@@ -69,7 +70,8 @@ public class StationFlatteningItemStackSchema extends Schema {
      * @param oldId Numeric block ID to add the rule to
      * @param meta Old metadata
      * @param tag Tag with the identifier and block state rules
-     * @param outputMeta New metadata
+     * @param outputMeta New metadata, or {@link MetaDependentIdConversion#UNSPECIFIED_META} to keep the old one
+     * @throws IllegalArgumentException if outputMeta is out of range
      */
     public static void putStateMetaRule(int oldId, int meta, NbtCompound tag, int outputMeta) {
         MetaDependentIdConversion rule;

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -49,10 +49,28 @@ public class StationFlatteningItemStackSchema extends Schema {
         putItem(oldId, id);
     }
 
+    /**
+     * Creates a metadata specific conversion rule for a block
+     * <p>
+     * <em>Must be used after the putState method<em/>
+     * @param oldId Numeric block ID to add the rule to
+     * @param meta Old metadata
+     * @param outputMeta New metadata
+     * @param id New identifier (including the namespace)
+     */
     public static void putStateMetaRule(int oldId, int meta, int outputMeta, String id) {
         putStateMetaRule(oldId, meta, outputMeta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)));
     }
 
+    /**
+     * Creates a metadata specific conversion rule for a block
+     * <p>
+     * <em>Must be used after the putState method<em/>
+     * @param oldId Numeric block ID to add the rule to
+     * @param meta Old metadata
+     * @param outputMeta New metadata
+     * @param tag Tag with the identifier and block state rules
+     */
     public static void putStateMetaRule(int oldId, int meta, int outputMeta, NbtCompound tag) {
         MetaDependentIdConversion rule;
         if (oldId >= 0 && oldId < OLD_ID_TO_BLOCKSTATE.length) {
@@ -78,6 +96,12 @@ public class StationFlatteningItemStackSchema extends Schema {
         return rule == null ? OLD_ID_TO_BLOCKSTATE[0].getDefaultTag() : rule.getTagForMeta(metadata);
     }
 
+    /**
+     * Replaces an old metadata with a new one for the given block
+     * @param stateId Numeric ID of the block
+     * @param metadata Old metadata
+     * @return New metadata or -1 if not specified
+     */
     public static int lookupMetadata(int stateId, int metadata) {
         MetaDependentIdConversion rule = null;
         if (stateId >= 0 && stateId < OLD_ID_TO_BLOCKSTATE.length) {

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -49,17 +49,33 @@ public class StationFlatteningItemStackSchema extends Schema {
         putItem(oldId, id);
     }
 
+    public static void putStateMetaRule(int oldId, int meta, String id) {
+        putStateMetaRule(oldId, meta, Util.make(new NbtCompound(), tag -> tag.putString("Name", id)));
+    }
+
+    public static void putStateMetaRule(int oldId, int meta, NbtCompound tag) {
+        MetaDependentIdConversion rule;
+        if (oldId >= 0 && oldId < OLD_ID_TO_BLOCKSTATE.length) {
+            rule = OLD_ID_TO_BLOCKSTATE[oldId];
+            if (rule != null) {
+                rule.addMetaDependentTag(meta, tag);
+                OLD_ID_TO_BLOCKSTATE[oldId] = rule;
+            }
+        }
+    }
+
     /**
      * Takes a numeric block ID and returns a block entry for the datafixer
      * @param stateId Numeric ID of the block
+     * @param metadata Metadata of the block
      * @return Dynamic which contains the new ID
      */
-    public static Dynamic<?> lookupState(int stateId) {
+    public static Dynamic<?> lookupState(int stateId, int metadata) {
         MetaDependentIdConversion rule = null;
         if (stateId >= 0 && stateId < OLD_ID_TO_BLOCKSTATE.length) {
             rule = OLD_ID_TO_BLOCKSTATE[stateId];
         }
-        return rule == null ? OLD_ID_TO_BLOCKSTATE[0].getDefaultTag() : rule.getDefaultTag();
+        return rule == null ? OLD_ID_TO_BLOCKSTATE[0].getDefaultTag() : rule.getTagForMeta(metadata);
     }
 
     /**

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -71,6 +71,12 @@ public class StationFlatteningItemStackSchema extends Schema {
         return dynamic == null ? "minecraft:air" : dynamic.get("Name").asString("");
     }
 
+    /**
+     * Reversed direction converter which turns an identifier into a numeric ID
+     * @param dynamic Dynamic with an identifier inside
+     * @return numeric ID
+     * @param <T> Type of the dynamic
+     */
     public static <T> int lookupOldBlockId(Dynamic<T> dynamic) {
         return BLOCK_TO_OLD_ID.getInt(dynamic.get("Name").asString(""));
     }

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/datafixer/schema/StationFlatteningItemStackSchema.java
@@ -7,8 +7,8 @@ import com.mojang.serialization.Dynamic;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import net.minecraft.nbt.NbtCompound;
 import net.modificationstation.stationapi.api.datafixer.TypeReferences;
-import net.modificationstation.stationapi.api.nbt.NbtOps;
 import net.modificationstation.stationapi.api.util.Util;
+import net.modificationstation.stationapi.api.vanillafix.util.MetaDependentIdConversion;
 
 import java.util.Map;
 import java.util.function.Supplier;
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 import static net.modificationstation.stationapi.impl.vanillafix.datafixer.VanillaDataFixerImpl.STATION_ID;
 
 public class StationFlatteningItemStackSchema extends Schema {
-    private static final Dynamic<?>[] OLD_ID_TO_BLOCKSTATE = new Dynamic[256];
+    private static final MetaDependentIdConversion[] OLD_ID_TO_BLOCKSTATE = new MetaDependentIdConversion[256];
     private static final Object2IntOpenHashMap<String> BLOCK_TO_OLD_ID = Util.make(new Object2IntOpenHashMap<>(256), map -> map.defaultReturnValue(0));
     private static final String[] OLD_ID_TO_ITEM = new String[32000];
     private static final Object2IntOpenHashMap<String> ITEM_TO_OLD_ID = Util.make(new Object2IntOpenHashMap<>(512), map -> map.defaultReturnValue(0));
@@ -45,8 +45,7 @@ public class StationFlatteningItemStackSchema extends Schema {
     public static void putState(int oldId, NbtCompound tag) {
         String id = tag.getString("Name");
         BLOCK_TO_OLD_ID.put(id, oldId);
-        Dynamic<?> dynamic = new Dynamic<>(NbtOps.INSTANCE, tag);
-        OLD_ID_TO_BLOCKSTATE[oldId] = dynamic;
+        OLD_ID_TO_BLOCKSTATE[oldId] = new MetaDependentIdConversion(tag);
         putItem(oldId, id);
     }
 
@@ -56,19 +55,11 @@ public class StationFlatteningItemStackSchema extends Schema {
      * @return Dynamic which contains the new ID
      */
     public static Dynamic<?> lookupState(int stateId) {
-        Dynamic<?> dynamic = null;
+        MetaDependentIdConversion rule = null;
         if (stateId >= 0 && stateId < OLD_ID_TO_BLOCKSTATE.length) {
-            dynamic = OLD_ID_TO_BLOCKSTATE[stateId];
+            rule = OLD_ID_TO_BLOCKSTATE[stateId];
         }
-        return dynamic == null ? OLD_ID_TO_BLOCKSTATE[0] : dynamic;
-    }
-
-    public static String lookupBlockId(int id) {
-        if (id < 0 || id >= OLD_ID_TO_BLOCKSTATE.length) {
-            return "minecraft:air";
-        }
-        Dynamic<?> dynamic = OLD_ID_TO_BLOCKSTATE[id];
-        return dynamic == null ? "minecraft:air" : dynamic.get("Name").asString("");
+        return rule == null ? OLD_ID_TO_BLOCKSTATE[0].getDefaultTag() : rule.getDefaultTag();
     }
 
     /**

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -8,15 +8,17 @@ import net.modificationstation.stationapi.api.nbt.NbtOps;
 /**
  * Provides advanced conversion rules which depend on metadata
  * <p>
- * Contains a default tag for unspecified metadata rules
+ * Contains a default tag for unspecified metadata rules and arrays which are null by default to save memory
  */
 public class MetaDependentIdConversion {
+    private static final int META_COUNT = 16;
     public static final int UNSPECIFIED_META = -1;
 
     @Getter
     private final Dynamic<?> defaultTag;
-    private final Dynamic<?>[] metaDependentTags = new Dynamic[16];
-    private final Integer[] outputMetas = new Integer[16];
+
+    private Dynamic<?>[] metaDependentTags = null;
+    private Integer[] outputMetas = null;
 
     /**
      * @param defaultTag Tag to be used for unspecified metadata rules
@@ -26,12 +28,16 @@ public class MetaDependentIdConversion {
     }
 
     /**
-     * Adds a meta rule
+     * Adds a meta rule and initializes arrays if necessary
      * @param meta Metadata of the rule
      * @param metaDependentTag Rule to be added
      * @param outputMeta New metadata of the converted block
      */
     public void addMetaDependentTag(int meta, NbtCompound metaDependentTag, int outputMeta) {
+        if (metaDependentTags == null || outputMetas == null) {
+            metaDependentTags = new Dynamic[META_COUNT];
+            outputMetas = new Integer[META_COUNT];
+        }
         if (meta < metaDependentTags.length) {
             metaDependentTags[meta] = toDynamic(metaDependentTag);
             outputMetas[meta] = outputMeta;
@@ -44,6 +50,9 @@ public class MetaDependentIdConversion {
      * @return Specific rule or default if unspecified
      */
     public Dynamic<?> getTagForMeta(int meta) {
+        if (metaDependentTags == null) {
+            return defaultTag;
+        }
         Dynamic<?> tag = metaDependentTags[meta];
         if (tag == null) {
             return defaultTag;
@@ -58,6 +67,9 @@ public class MetaDependentIdConversion {
      */
     public int getOutputMeta(int meta) {
         Integer outputMeta = null;
+        if (outputMetas == null) {
+            return UNSPECIFIED_META;
+        }
         if (meta < outputMetas.length) {
             outputMeta = outputMetas[meta];
         }

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -17,7 +17,7 @@ public class MetaDependentIdConversion {
     public static final int UNSPECIFIED_META = -1;
 
     @Getter
-    private final Dynamic<?> defaultTag;
+    private Dynamic<?> defaultTag;
 
     private Dynamic<?>[] metaDependentTags = null;
     private int[] outputMetas = null;
@@ -26,6 +26,16 @@ public class MetaDependentIdConversion {
      * @param defaultTag Tag to be used for unspecified metadata rules
      */
     public MetaDependentIdConversion(NbtCompound defaultTag) {
+        this.defaultTag = toDynamic(defaultTag);
+    }
+
+    /**
+     * Replaces the tag used for metadata values that have no rule of their own
+     * <p>
+     * Rules added earlier are kept, as each of them carries its own tag
+     * @param defaultTag New tag to be used for unspecified metadata rules
+     */
+    public void setDefaultTag(NbtCompound defaultTag) {
         this.defaultTag = toDynamic(defaultTag);
     }
 

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import net.minecraft.nbt.NbtCompound;
 import net.modificationstation.stationapi.api.nbt.NbtOps;
 
+import java.util.Arrays;
+
 /**
  * Provides advanced conversion rules which depend on metadata
  * <p>
@@ -18,7 +20,7 @@ public class MetaDependentIdConversion {
     private final Dynamic<?> defaultTag;
 
     private Dynamic<?>[] metaDependentTags = null;
-    private Integer[] outputMetas = null;
+    private int[] outputMetas = null;
 
     /**
      * @param defaultTag Tag to be used for unspecified metadata rules
@@ -36,7 +38,8 @@ public class MetaDependentIdConversion {
     public void addMetaDependentTag(int meta, NbtCompound metaDependentTag, int outputMeta) {
         if (metaDependentTags == null || outputMetas == null) {
             metaDependentTags = new Dynamic[META_COUNT];
-            outputMetas = new Integer[META_COUNT];
+            outputMetas = new int[META_COUNT];
+            Arrays.fill(outputMetas, UNSPECIFIED_META);
         }
         if (meta < metaDependentTags.length) {
             metaDependentTags[meta] = toDynamic(metaDependentTag);
@@ -66,14 +69,14 @@ public class MetaDependentIdConversion {
      * @return New metadata or -1 if not specified
      */
     public int getOutputMeta(int meta) {
-        Integer outputMeta = null;
+        int outputMeta = UNSPECIFIED_META;
         if (outputMetas == null) {
             return UNSPECIFIED_META;
         }
         if (meta < outputMetas.length) {
             outputMeta = outputMetas[meta];
         }
-        return outputMeta == null ? UNSPECIFIED_META : outputMeta;
+        return outputMeta;
     }
 
     private Dynamic<?> toDynamic(NbtCompound tag) {

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -1,0 +1,63 @@
+package net.modificationstation.stationapi.api.vanillafix.util;
+
+import com.mojang.serialization.Dynamic;
+import lombok.Getter;
+import net.minecraft.nbt.NbtCompound;
+import net.modificationstation.stationapi.api.nbt.NbtOps;
+
+/**
+ * Provides advanced conversion rules which depend on metadata
+ * <p>
+ * Contains a default tag for unspecified metadata rules
+ */
+public class MetaDependentIdConversion {
+    @Getter
+    private final Dynamic<?> defaultTag;
+    private final Dynamic<?>[] metaDependentTags = new Dynamic[16];
+
+    /**
+     * @param defaultTag Tag to be used for unspecified metadata rules
+     */
+    public MetaDependentIdConversion(NbtCompound defaultTag) {
+        this.defaultTag = toDynamic(defaultTag);
+    }
+
+    /**
+     * Adds a meta rule
+     * @param meta Metadata of the rule
+     * @param metaDependentTag Rule to be added
+     */
+    public void addMetaDependentTag(int meta, NbtCompound metaDependentTag) {
+        if (meta < metaDependentTags.length) {
+            metaDependentTags[meta] = toDynamic(metaDependentTag);
+        }
+    }
+
+    /**
+     * Adds the same meta rule across an entire interval
+     * @param interval Interval to determine metadata values of the rule
+     * @param intervalTag Rule to be added
+     */
+    public void addMetaDependentTagInterval(MetaIntervalToTag interval, NbtCompound intervalTag) {
+        for (int meta = interval.start(); meta < interval.end(); meta++) {
+            addMetaDependentTag(meta, intervalTag);
+        }
+    }
+
+    /**
+     * Provides a conversion rule for a given metadata value
+     * @param meta Metadata to check the rule for
+     * @return Specific rule or default if unspecified
+     */
+    public Dynamic<?> getTagForMeta(int meta) {
+        Dynamic<?> tag = metaDependentTags[meta];
+        if (tag == null) {
+            return defaultTag;
+        }
+        return tag;
+    }
+
+    private Dynamic<?> toDynamic(NbtCompound tag) {
+        return new Dynamic<>(NbtOps.INSTANCE, tag);
+    }
+}

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -33,9 +33,18 @@ public class MetaDependentIdConversion {
      * Adds a meta rule and initializes arrays if necessary
      * @param meta Metadata of the rule
      * @param metaDependentTag Rule to be added
-     * @param outputMeta New metadata of the converted block
+     * @param outputMeta New metadata of the converted block,
+     *                   or {@link #UNSPECIFIED_META} to keep the original metadata
+     * @throws IllegalArgumentException if outputMeta is neither {@link #UNSPECIFIED_META}
+     *                                  nor a valid metadata value
      */
     public void addMetaDependentTag(int meta, NbtCompound metaDependentTag, int outputMeta) {
+        if (outputMeta != UNSPECIFIED_META && (outputMeta < 0 || outputMeta >= META_COUNT)) {
+            throw new IllegalArgumentException(
+                    "Output metadata " + outputMeta + " is out of range, it must be between 0 and " +
+                    (META_COUNT - 1) + ", or " + UNSPECIFIED_META + " to keep the original metadata"
+            );
+        }
         if (metaDependentTags == null || outputMetas == null) {
             metaDependentTags = new Dynamic[META_COUNT];
             outputMetas = new int[META_COUNT];

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -31,15 +31,20 @@ public class MetaDependentIdConversion {
 
     /**
      * Adds a meta rule and initializes arrays if necessary
-     * @param meta Metadata of the rule
+     * @param meta Metadata of the rule, must be a valid metadata value
      * @param metaDependentTag Rule to be added
      * @param outputMeta New metadata of the converted block,
      *                   or {@link #UNSPECIFIED_META} to keep the original metadata
-     * @throws IllegalArgumentException if outputMeta is neither {@link #UNSPECIFIED_META}
-     *                                  nor a valid metadata value
+     * @throws IllegalArgumentException if meta is out of range, or if outputMeta is neither
+     *                                  {@link #UNSPECIFIED_META} nor a valid metadata value
      */
     public void addMetaDependentTag(int meta, NbtCompound metaDependentTag, int outputMeta) {
-        if (outputMeta != UNSPECIFIED_META && (outputMeta < 0 || outputMeta >= META_COUNT)) {
+        if (isOutOfRange(meta)) {
+            throw new IllegalArgumentException(
+                    "Metadata " + meta + " is out of range, it must be between 0 and " + (META_COUNT - 1)
+            );
+        }
+        if (outputMeta != UNSPECIFIED_META && isOutOfRange(outputMeta)) {
             throw new IllegalArgumentException(
                     "Output metadata " + outputMeta + " is out of range, it must be between 0 and " +
                     (META_COUNT - 1) + ", or " + UNSPECIFIED_META + " to keep the original metadata"
@@ -50,19 +55,17 @@ public class MetaDependentIdConversion {
             outputMetas = new int[META_COUNT];
             Arrays.fill(outputMetas, UNSPECIFIED_META);
         }
-        if (meta < metaDependentTags.length) {
-            metaDependentTags[meta] = toDynamic(metaDependentTag);
-            outputMetas[meta] = outputMeta;
-        }
+        metaDependentTags[meta] = toDynamic(metaDependentTag);
+        outputMetas[meta] = outputMeta;
     }
 
     /**
      * Provides a conversion rule for a given metadata value
      * @param meta Metadata to check the rule for
-     * @return Specific rule or default if unspecified
+     * @return Specific rule, or default if unspecified or out of range
      */
     public Dynamic<?> getTagForMeta(int meta) {
-        if (metaDependentTags == null) {
+        if (metaDependentTags == null || isOutOfRange(meta)) {
             return defaultTag;
         }
         Dynamic<?> tag = metaDependentTags[meta];
@@ -75,17 +78,17 @@ public class MetaDependentIdConversion {
     /**
      * Replaces an old metadata value with a new one
      * @param meta Old metadata to be replaced
-     * @return New metadata or -1 if not specified
+     * @return New metadata, or {@link #UNSPECIFIED_META} if unspecified or out of range
      */
     public int getOutputMeta(int meta) {
-        int outputMeta = UNSPECIFIED_META;
-        if (outputMetas == null) {
+        if (outputMetas == null || isOutOfRange(meta)) {
             return UNSPECIFIED_META;
         }
-        if (meta < outputMetas.length) {
-            outputMeta = outputMetas[meta];
-        }
-        return outputMeta;
+        return outputMetas[meta];
+    }
+
+    private static boolean isOutOfRange(int meta) {
+        return meta < 0 || meta >= META_COUNT;
     }
 
     private Dynamic<?> toDynamic(NbtCompound tag) {

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -11,9 +11,12 @@ import net.modificationstation.stationapi.api.nbt.NbtOps;
  * Contains a default tag for unspecified metadata rules
  */
 public class MetaDependentIdConversion {
+    public static final int UNSPECIFIED_META = -1;
+
     @Getter
     private final Dynamic<?> defaultTag;
     private final Dynamic<?>[] metaDependentTags = new Dynamic[16];
+    private final Integer[] outputMetas = new Integer[16];
 
     /**
      * @param defaultTag Tag to be used for unspecified metadata rules
@@ -26,10 +29,12 @@ public class MetaDependentIdConversion {
      * Adds a meta rule
      * @param meta Metadata of the rule
      * @param metaDependentTag Rule to be added
+     * @param outputMeta New metadata of the converted block
      */
-    public void addMetaDependentTag(int meta, NbtCompound metaDependentTag) {
+    public void addMetaDependentTag(int meta, NbtCompound metaDependentTag, int outputMeta) {
         if (meta < metaDependentTags.length) {
             metaDependentTags[meta] = toDynamic(metaDependentTag);
+            outputMetas[meta] = outputMeta;
         }
     }
 
@@ -40,7 +45,7 @@ public class MetaDependentIdConversion {
      */
     public void addMetaDependentTagInterval(MetaIntervalToTag interval, NbtCompound intervalTag) {
         for (int meta = interval.start(); meta < interval.end(); meta++) {
-            addMetaDependentTag(meta, intervalTag);
+            addMetaDependentTag(meta, intervalTag, interval.outputMeta());
         }
     }
 
@@ -55,6 +60,14 @@ public class MetaDependentIdConversion {
             return defaultTag;
         }
         return tag;
+    }
+
+    public int getOutputMeta(int meta) {
+        Integer outputMeta = null;
+        if (meta < outputMetas.length) {
+            outputMeta = outputMetas[meta];
+        }
+        return outputMeta == null ? UNSPECIFIED_META : outputMeta;
     }
 
     private Dynamic<?> toDynamic(NbtCompound tag) {

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaDependentIdConversion.java
@@ -39,17 +39,6 @@ public class MetaDependentIdConversion {
     }
 
     /**
-     * Adds the same meta rule across an entire interval
-     * @param interval Interval to determine metadata values of the rule
-     * @param intervalTag Rule to be added
-     */
-    public void addMetaDependentTagInterval(MetaIntervalToTag interval, NbtCompound intervalTag) {
-        for (int meta = interval.start(); meta < interval.end(); meta++) {
-            addMetaDependentTag(meta, intervalTag, interval.outputMeta());
-        }
-    }
-
-    /**
      * Provides a conversion rule for a given metadata value
      * @param meta Metadata to check the rule for
      * @return Specific rule or default if unspecified
@@ -62,6 +51,11 @@ public class MetaDependentIdConversion {
         return tag;
     }
 
+    /**
+     * Replaces an old metadata value with a new one
+     * @param meta Old metadata to be replaced
+     * @return New metadata or -1 if not specified
+     */
     public int getOutputMeta(int meta) {
         Integer outputMeta = null;
         if (meta < outputMetas.length) {

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaIntervalToTag.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaIntervalToTag.java
@@ -1,0 +1,6 @@
+package net.modificationstation.stationapi.api.vanillafix.util;
+
+import net.minecraft.nbt.NbtCompound;
+
+public record MetaIntervalToTag(int start, int end, NbtCompound tag) {
+}

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaIntervalToTag.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaIntervalToTag.java
@@ -2,5 +2,5 @@ package net.modificationstation.stationapi.api.vanillafix.util;
 
 import net.minecraft.nbt.NbtCompound;
 
-public record MetaIntervalToTag(int start, int end, NbtCompound tag) {
+public record MetaIntervalToTag(int start, int end, NbtCompound tag, int outputMeta) {
 }

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaIntervalToTag.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/api/vanillafix/util/MetaIntervalToTag.java
@@ -1,6 +1,0 @@
-package net.modificationstation.stationapi.api.vanillafix.util;
-
-import net.minecraft.nbt.NbtCompound;
-
-public record MetaIntervalToTag(int start, int end, NbtCompound tag, int outputMeta) {
-}

--- a/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/impl/vanillafix/datafixer/VanillaDataFixerImpl.java
+++ b/station-vanilla-fix-v0/src/main/java/net/modificationstation/stationapi/impl/vanillafix/datafixer/VanillaDataFixerImpl.java
@@ -52,9 +52,12 @@ public final class VanillaDataFixerImpl {
     private static void registerFixer(DataFixerRegisterEvent event) {
         DataFixers.registerFixer(NAMESPACE, executor -> {
             DataFixerBuilder builder = new DataFixerBuilder(CURRENT_VERSION);
+            // This schema provides the conversion rules for everything found inside chunks:
+            // Entities, block entities, players, and items
             Schema schema19132 = builder.addSchema(19132, McRegionSchemaB1_7_3::new);
             Schema schema69420 = builder.addSchema(69420, StationFlatteningItemStackSchema::new);
             builder.addFixer(new McRegionToStationFlatteningItemStackFix(schema69420, "McRegionToStationFlatteningItemStackFix"));
+            // This schema gets used for converting blocks from the standard Beta 1.7.3 world format
             Schema schema69421 = builder.addSchema(69421, StationFlatteningChunkSchema::new);
             builder.addFixer(new McRegionToStationFlatteningChunkFix(schema69421, "McRegionToStationFlatteningChunkFix"));
             return builder.build().fixer();


### PR DESCRIPTION
### Overview
Expands the block datafixer with an intermediary data structure `MetaDependentIdConversion` to allow for each metadata to output a different block ID and also change the output metadata. New rules can be added _any_ time after a default rule is specified using a `putState` method. Metadata stays the same whenever the default rule applies.

An example of birch wood being converted to purple wool can be found in the test mod:
`putStateMetaRule(17, 2, "minecraft:wool", 10);`

### Documentation
New and existing block conversion methods for `StationFlatteningBlockSchema` have been documented so the code becomes easier to understand for other developers. Some other datafixer classes have been partially documented too.

### Compatibility
Most changes are inside the `StationFlatteningBlockSchema` class. The existing methods have the same inputs as before so none of the old datafixer configurations are broken by this.