### PR TITLE
fix: fix: remove duplicate cacti tag

### DIFF
--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,8 +1,0 @@
-fix: fix: remove duplicate cacti tag
-
-- remove duplicate tag station-vanilla-fix-v0\src\main\resources\data\c\stationapi\tags\blocks\cacti.json
-- remove duplicate tag station-vanilla-fix-v0\src\main\resources\data\c\stationapi\tags\items\cacti.json
-
-Fixes #281
-
-Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/COMMITMSG
+++ b/COMMITMSG
@@ -1,0 +1,8 @@
+fix: fix: remove duplicate cacti tag
+
+- remove duplicate tag station-vanilla-fix-v0\src\main\resources\data\c\stationapi\tags\blocks\cacti.json
+- remove duplicate tag station-vanilla-fix-v0\src\main\resources\data\c\stationapi\tags\items\cacti.json
+
+Fixes #281
+
+Signed-off-by: Vedant Madane <6527493+VedantMadane@users.noreply.github.com>

--- a/station-vanilla-fix-v0/src/main/resources/data/c/stationapi/tags/blocks/cacti.json
+++ b/station-vanilla-fix-v0/src/main/resources/data/c/stationapi/tags/blocks/cacti.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "minecraft:cactus"
-  ]
-}

--- a/station-vanilla-fix-v0/src/main/resources/data/c/stationapi/tags/items/cacti.json
+++ b/station-vanilla-fix-v0/src/main/resources/data/c/stationapi/tags/items/cacti.json
@@ -1,5 +1,0 @@
-{
-  "values": [
-    "minecraft:cactus"
-  ]
-}


### PR DESCRIPTION
## Summary

fix: remove duplicate cacti tag

## Changes

- remove duplicate tag station-vanilla-fix-v0\src\main\resources\data\c\stationapi\tags\blocks\cacti.json
- remove duplicate tag station-vanilla-fix-v0\src\main\resources\data\c\stationapi\tags\items\cacti.json

Fixes #281
